### PR TITLE
Add requires logic to not load CSV all the times

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,19 +1,19 @@
 name = "PSRClassesInterface"
 uuid = "1eab49e5-27d8-4905-b9f6-327b6ea666c4"
-version = "0.4.2"
+version = "0.5.0"
 
 [deps]
-CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
-CSV = "0.10"
 JSON = "0.21"
 julia = "1.6"
 
 [extras]
+CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Test", "CSV"]

--- a/src/OpenBinary/OpenBinary.jl
+++ b/src/OpenBinary/OpenBinary.jl
@@ -1,7 +1,8 @@
 module OpenBinary
 
 import PSRClassesInterface
-import Dates
+# Load packages defined in the upper module PSRClassesInterface
+import PSRClassesInterface.Dates
 
 const PSRI = PSRClassesInterface
 

--- a/src/OpenCSV/OpenCSV.jl
+++ b/src/OpenCSV/OpenCSV.jl
@@ -1,8 +1,9 @@
 module OpenCSV
 
 import PSRClassesInterface
-import Dates
-import CSV
+# Load packages defined in the upper module PSRClassesInterface
+import PSRClassesInterface.Dates
+import PSRClassesInterface.CSV
 
 const PSRI = PSRClassesInterface
 

--- a/src/PMD/PMD.jl
+++ b/src/PMD/PMD.jl
@@ -1,6 +1,8 @@
 module PMD
 
-import Dates
+import PSRClassesInterface
+# Load packages defined in the upper module PSRClassesInterface
+import PSRClassesInterface.Dates
 
 const _PMDS_BASE_PATH = joinpath(@__DIR__(), "pmds")
 

--- a/src/PSRClassesInterface.jl
+++ b/src/PSRClassesInterface.jl
@@ -2,10 +2,14 @@ module PSRClassesInterface
 
 import Dates
 import JSON
-import CSV
+import Requires
 
 @static if VERSION < v"1.6"
     error("Julia version $VERSION not supported by PSRClassesInterface, upgrade to 1.6 or later")
+end
+
+function __init__()
+    Requires.@require CSV="336ed68f-0bac-5ca0-87d4-7b16caf5d00b" include("OpenCSV/OpenCSV.jl")
 end
 
 # simple and generic interface
@@ -18,7 +22,6 @@ include("time_series_utils.jl")
 include("utils.jl")
 
 # submodules
-include("OpenCSV/OpenCSV.jl")
 include("PMD/PMD.jl")
 include("OpenBinary/OpenBinary.jl")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ import PSRClassesInterface
 import Dates
 using Test
 const PSRI = PSRClassesInterface
+using CSV
 
 PATH_CASE_0 = joinpath(".", "data", "caso0")
 


### PR DESCRIPTION
Sometimes loading CSV just because we want PSRClassesInterface.jl might be undesirable, this PR lets you use the functionality of OpenCSV when you define CSV after PSRClassesInterface
```julia
using PSRClassesInterface
using CSV

# All functionalities from open CSV work
```