### PR TITLE
Move default relations to `Data`

### DIFF
--- a/docs/src/examples/modification.md
+++ b/docs/src/examples/modification.md
@@ -60,7 +60,7 @@ PSRI.set_related!(
     "PSRBus", 
     serie_1_index, 
     bus_1_index , 
-    relation_type = PSRI.RELATION_FROM
+    relation_type = PSRI.PMD.RELATION_FROM
     )
 
 PSRI.set_related!(
@@ -69,7 +69,7 @@ PSRI.set_related!(
     "PSRBus", 
     serie_1_index, 
     bus_2_index , 
-    relation_type = PSRI.RELATION_TO
+    relation_type = PSRI.PMD.RELATION_TO
     )
 ```
 

--- a/docs/src/examples/reading_demands.md
+++ b/docs/src/examples/reading_demands.md
@@ -23,7 +23,7 @@ Now, we can read the demand segments and the map between demands and demand segm
 ```@example demand
 dem_seg = PSRI.mapped_vector(data, "PSRDemandSegment", "Demanda", Float64, "block")
 
-seg2dem = PSRI.get_map(data, "PSRDemandSegment", "PSRDemand", relation_type = PSRI.RELATION_1_TO_1)
+seg2dem = PSRI.get_map(data, "PSRDemandSegment", "PSRDemand", relation_type = PSRI.PMD.RELATION_1_TO_1)
 
 dem_size = PSRI.max_elements(data, "PSRDemand")
 
@@ -60,8 +60,8 @@ Now we have the values of the demands, we can obtain the values of demand for ea
 Each demand has a set of loads, which define how much of this demand corresponds to each bus.  We can begin by reading the loads and its relations with demands and buses:
 ```@example demand
 loads = PSRI.mapped_vector(data, "PSRLoad", "P", Float64, "block")
-lod2dem = PSRI.get_map(data, "PSRLoad", "PSRDemand", relation_type = PSRI.RELATION_1_TO_1)
-lod2bus = PSRI.get_map(data, "PSRLoad", "PSRBus", relation_type = PSRI.RELATION_1_TO_1)
+lod2dem = PSRI.get_map(data, "PSRLoad", "PSRDemand", relation_type = PSRI.PMD.RELATION_1_TO_1)
+lod2bus = PSRI.get_map(data, "PSRLoad", "PSRBus", relation_type = PSRI.PMD.RELATION_1_TO_1)
 ; nothing # hide
 ```
 
@@ -116,7 +116,7 @@ data = PSRI.initialize_study(
 ```
 We discover the necessary infos of the thermal plants indirectly through `PSRFuelConsumption`:
 ```@example ther_prices
-fuelcons2ther = PSRI.get_map(data,"PSRFuelConsumption", "PSRThermalPlant"; relation_type = PSRI.RELATION_1_TO_1)
+fuelcons2ther = PSRI.get_map(data,"PSRFuelConsumption", "PSRThermalPlant"; relation_type = PSRI.PMD.RELATION_1_TO_1)
 
 ther_size = PSRI.max_elements(data, "PSRThermalPlant")
 fuelcons_size = PSRI.max_elements(data, "PSRFuelConsumption")
@@ -127,7 +127,7 @@ Next, we get the O&M cost, the specific consumption and the relation with fuels 
 ```@example ther_prices
 om_cost = PSRI.mapped_vector(data, "PSRFuelConsumption", "O&MCost", Float64)
 spec_consum = PSRI.mapped_vector(data, "PSRFuelConsumption", "CEsp", Float64, "segment", "block")
-fuelcons2fuel = PSRI.get_map(data, "PSRFuelConsumption", "PSRFuel"; relation_type = PSRI.RELATION_1_TO_1)
+fuelcons2fuel = PSRI.get_map(data, "PSRFuelConsumption", "PSRFuel"; relation_type = PSRI.PMD.RELATION_1_TO_1)
 fuel_cost = PSRI.mapped_vector(data, "PSRFuel", "Custo", Float64)
 
 PSRI.update_vectors!(data)

--- a/docs/src/examples/reading_relations.md
+++ b/docs/src/examples/reading_relations.md
@@ -75,8 +75,8 @@ data = PSRI.initialize_study(
 ```
 Next, we get from which bus each circuit starts and which bus it goes to with `get_map`:
 ```@example cir_bus
-cir2bus_to = PSRI.get_map(data, "PSRSerie", "PSRBus"; relation_type = PSRI.RELATION_TO)
-cir2bus_from = PSRI.get_map(data, "PSRSerie", "PSRBus"; relation_type = PSRI.RELATION_FROM)
+cir2bus_to = PSRI.get_map(data, "PSRSerie", "PSRBus"; relation_type = PSRI.PMD.RELATION_TO)
+cir2bus_from = PSRI.get_map(data, "PSRSerie", "PSRBus"; relation_type = PSRI.PMD.RELATION_FROM)
 ; nothing # hide
 ```
 Now we can build the incidence matrix. Each row corresponds to a circuit and each column corresponds to a bus. The element at the index (i,j) is -1 if the circuit i starts from the bus j, 1 if it goes to this bus, and 0 if they both have no relation:

--- a/src/OpenStudy/relations.jl
+++ b/src/OpenStudy/relations.jl
@@ -12,7 +12,10 @@ end
 
     Returns true if there is a relation with attribute 'relation_attribute' in a 'Vector{PMD.Relation}'
 """
-function _has_relation_attribute(relations::Vector{PMD.Relation}, relation_attribute::String)
+function _has_relation_attribute(
+    relations::Vector{PMD.Relation},
+    relation_attribute::String,
+)
     has_relation_attribute = false
     for relation in relations
         if relation.attribute == relation_attribute
@@ -27,7 +30,10 @@ end
 
     Returns true if there is a relation with type 'relation_type' in a 'Vector{PMD.Relation}'
 """
-function _has_relation_type(relations::Vector{PMD.Relation}, relation_type::PMD.RelationType)
+function _has_relation_type(
+    relations::Vector{PMD.Relation},
+    relation_type::PMD.RelationType,
+)
     has_relation_type = false
     for relation in relations
         if relation.type == relation_type
@@ -57,13 +63,15 @@ function validate_relation(data::Data, source::String, target::String)
     validate_relation(data::Data, source::String)
 
     if !haskey(data.relation_mapper[source], target)
-        if !haskey(data.relation_mapper, target) || !haskey(data.relation_mapper[target], source)
+        if !haskey(data.relation_mapper, target) ||
+           !haskey(data.relation_mapper[target], source)
             error("No relation from $source to $target.")
         end
-        if haskey(data.relation_mapper, target) && haskey(data.relation_mapper[target], source)
+        if haskey(data.relation_mapper, target) &&
+           haskey(data.relation_mapper[target], source)
             error(
                 "No relation from $source to $target." *
-                "There is a reverse relation from $target to $source."
+                "There is a reverse relation from $target to $source.",
             )
         end
     end
@@ -74,20 +82,28 @@ end
 
     Returns an error message if there is no relation between collections 'source' and 'target' with type 'relation_type'
 """
-function validate_relation(data::Data, source::String, target::String, relation_type::PMD.RelationType)
+function validate_relation(
+    data::Data,
+    source::String,
+    target::String,
+    relation_type::PMD.RelationType,
+)
     validate_relation(data, source, target)
 
     if !_has_relation_type(data.relation_mapper[source][target], relation_type)
-        if haskey(data.relation_mapper,target) && haskey(data.relation_mapper[target], source)
+        if haskey(data.relation_mapper, target) &&
+           haskey(data.relation_mapper[target], source)
             if _has_relation_type(data.relation_mapper[target][source], relation_type)
                 error(
                     "No relation from $(source) to $(target) with type $(relation_type)." *
                     " The there is a reverse relation from $(target) to " *
-                    "$(source)  with type $(relation_type)."
+                    "$(source)  with type $(relation_type).",
                 )
             end
         end
-        error("There is no relation with type $(relation_type) between collections $(source) and $(target)")
+        error(
+            "There is no relation with type $(relation_type) between collections $(source) and $(target)",
+        )
     end
 end
 
@@ -96,30 +112,45 @@ end
 
     Returns an error message if there is no relation between collections 'source' and 'target' with attribute 'relation_attribute'
 """
-function validate_relation(data::Data, source::String, target::String, relation_attribute::String)
+function validate_relation(
+    data::Data,
+    source::String,
+    target::String,
+    relation_attribute::String,
+)
     validate_relation(data, source, target)
 
     if !_has_relation_attribute(data.relation_mapper[source][target], relation_attribute)
-        if haskey(data.relation_mapper,target) && haskey(data.relation_mapper[target], source)
-            if _has_relation_attribute(data.relation_mapper[target][source], relation_attribute)
+        if haskey(data.relation_mapper, target) &&
+           haskey(data.relation_mapper[target], source)
+            if _has_relation_attribute(
+                data.relation_mapper[target][source],
+                relation_attribute,
+            )
                 error(
                     "No relation from $(source) to $(target) with attribute $(relation_attribute)." *
                     " The there is a reverse relation from $(target) to " *
-                    "$(source)  with attribute $(relation_attribute)."
+                    "$(source)  with attribute $(relation_attribute).",
                 )
             end
         end
-        error("There is no relation with attribute $(relation_attribute) between collections $(source) and $(target)")
+        error(
+            "There is no relation with attribute $(relation_attribute) between collections $(source) and $(target)",
+        )
     end
 end
 
 """
     _get_relation_attribute(data::Data, source::String, target::String, relation_type::PMD.RelationType)
-    
+
     Returns the attribute that represents a relation between elements from collections 'source' and 'target'
 """
-function _get_relation_attribute(data::Data, source::String, target::String, relation_type::PMD.RelationType)
-    
+function _get_relation_attribute(
+    data::Data,
+    source::String,
+    target::String,
+    relation_type::PMD.RelationType,
+)
     validate_relation(data, source, target, relation_type)
 
     relations = data.relation_mapper[source][target]
@@ -142,7 +173,7 @@ end
         source_index::Integer,
         relation_attribute::String,
     )
-    
+
     Returns the 'target' element's index stored in 'source' element in the attribute 'relation_attribute'
 """
 function _get_target_index_from_relation(
@@ -174,7 +205,7 @@ end
         target_id::Integer,
         relation_attribute::String,
     )
-    
+
     Returns indices of all elements from collection 'source' that have an attribute 'relation_attribute' that stores the given 'target_id'
 """
 function _get_sources_indices_from_relations(
@@ -211,7 +242,7 @@ end
 
 """
     _get_element_related(data::Data, collection::String, index::Integer)
-    
+
     Returns two dictionaries:
     - Dict{target_collection, Dict{attribute, Vector{target_index}}}
     - Dict{source_collection, Dict{attribute, Vector{source_index}}}
@@ -222,9 +253,8 @@ end
 function _get_element_related(data::Data, collection::String, index::Integer)
     element = _get_element(data, collection, index)
 
-    
-    relations_as_source = Dict{String, Dict{String,Vector{Int}}}() # Dict{target_collection, Dict{attribute, Vector{target_index}}}
-    relations_as_target = Dict{String, Dict{String,Vector{Int}}}() # Dict{source_collection, Dict{attribute, Vector{source_index}}}
+    relations_as_source = Dict{String, Dict{String, Vector{Int}}}() # Dict{target_collection, Dict{attribute, Vector{target_index}}}
+    relations_as_target = Dict{String, Dict{String, Vector{Int}}}() # Dict{source_collection, Dict{attribute, Vector{source_index}}}
 
     # Relations where the element is source
     if haskey(data.relation_mapper, collection)
@@ -233,10 +263,18 @@ function _get_element_related(data::Data, collection::String, index::Integer)
             for relation in relations_vector
                 if haskey(element, relation.attribute) # has a relation as source
                     target_indices =
-                        _get_target_index_from_relation(data, collection, index, relation.attribute)
+                        _get_target_index_from_relation(
+                            data,
+                            collection,
+                            index,
+                            relation.attribute,
+                        )
                     if !isempty(target_indices)
                         relations_as_source[target][relation.attribute] = Vector{Int}()
-                        append!(relations_as_source[target][relation.attribute],target_indices)
+                        append!(
+                            relations_as_source[target][relation.attribute],
+                            target_indices,
+                        )
                     end
                 end
             end
@@ -245,7 +283,7 @@ function _get_element_related(data::Data, collection::String, index::Integer)
             end
         end
     end
-    
+
     # Relations where the element is target
     for (source, related) in data.relation_mapper
         for (target, relations) in related
@@ -257,11 +295,14 @@ function _get_element_related(data::Data, collection::String, index::Integer)
                         source,
                         collection,
                         element["reference_id"],
-                        relation.attribute
+                        relation.attribute,
                     )
                     if !isempty(source_indices)
                         relations_as_target[source][relation.attribute] = Vector{Int}()
-                        append!(relations_as_target[source][relation.attribute], source_indices)
+                        append!(
+                            relations_as_target[source][relation.attribute],
+                            source_indices,
+                        )
                     end
                 end
                 if isempty(relations_as_target[source])
@@ -270,7 +311,7 @@ function _get_element_related(data::Data, collection::String, index::Integer)
             end
         end
     end
-    
+
     return relations_as_source, relations_as_target
 end
 
@@ -337,10 +378,9 @@ function relations_summary(data::Data, collection::String, index::Integer)
             )
         end
     end
-    
+
     return
 end
-
 
 """
     check_relation_scalar(relation_type::PMD.RelationType)
@@ -497,7 +537,6 @@ function get_map(
 
     # TODO improve this quadratic loop
     for (idx_from, el_from) in enumerate(vec_from)
-
         id_to = get(el_from, raw_field, -1)
 
         found = false
@@ -512,7 +551,6 @@ function get_map(
         if !found && !allow_empty
             error("No $lst_to element matching $lst_from of index $idx_from")
         end
-
     end
     return out
 end

--- a/src/OpenStudy/relations.jl
+++ b/src/OpenStudy/relations.jl
@@ -1,124 +1,150 @@
 """
-    is_vector_relation(relation::RelationType)
+    is_vector_relation(relation::PMD.RelationType)
 
 Returns true is `relation` is a vector relation.
 """
-
-function is_vector_relation(relation)
-    return relation == RELATION_1_TO_N || relation == RELATION_BACKED
+function is_vector_relation(relation::PMD.RelationType)
+    return relation == PMD.RELATION_1_TO_N || relation == PMD.RELATION_BACKED
 end
 
-const _INNER_KEY = Tuple{String, RelationType}
-const _INNER_DICT = Dict{_INNER_KEY, String}
-const _RELATIONS = Dict{String, _INNER_DICT}(
-    "PSRThermalPlant" => _INNER_DICT(
-        ("PSRFuel", RELATION_1_TO_N) => "fuels",
-        ("PSRSystem", RELATION_1_TO_1) => "system",
-    ),
-    "PSRFuelConsumption" => _INNER_DICT(
-        ("PSRFuel", RELATION_1_TO_1) => "fuel",
-        ("PSRThermalPlant", RELATION_1_TO_1) => "plant",
-    ),
-    "PSRHydroPlant" => _INNER_DICT(
-        ("PSRGaugingStation", RELATION_1_TO_1) => "station",
-        ("PSRSystem", RELATION_1_TO_1) => "system",
-        ("PSRHydroPlant", RELATION_TURBINE_TO) => "turbinning",
-        ("PSRHydroPlant", RELATION_SPILL_TO) => "spilling",
-        ("PSRHydroPlant", RELATION_INFILTRATE_TO) => "filtration",
-        ("PSRHydroPlant", RELATION_STORED_ENERGY_DONWSTREAM) => "storedenergy",
-    ),
-    "PSRGndPlant" => _INNER_DICT(
-        ("PSRGndGaugingStation", RELATION_1_TO_1) => "station",
-        ("PSRSystem", RELATION_1_TO_1) => "system",
-    ),
-    "PSRGaugingStation" =>
-        _INNER_DICT(("PSRGaugingStation", RELATION_1_TO_1) => "downstream"),
-    "PSRBattery" => _INNER_DICT(
-        ("PSRBus", RELATION_1_TO_1) => "bus",
-        ("PSRSystem", RELATION_1_TO_1) => "system",
-    ),
-    "PSRGenerator" => _INNER_DICT(
-        ("PSRBus", RELATION_1_TO_1) => "bus",
-        ("PSRThermalPlant", RELATION_1_TO_1) => "plant",
-        ("PSRHydroPlant", RELATION_1_TO_1) => "plant",
-        ("PSRGndPlant", RELATION_1_TO_1) => "plant",
-    ),
-    # "PSRFuel" => _INNER_DICT(
-    #     "PSRSystem", RELATION_1_TO_1) => "system",
-    # ),
-    "PSRDemandSegment" => _INNER_DICT(
-        ("PSRDemand", RELATION_1_TO_1) => "demand",
-        ("PSRSystem", RELATION_1_TO_1) => "system",
-    ),
-    "PSRDemand" => _INNER_DICT(("PSRSystem", RELATION_1_TO_1) => "system"),
-    "PSRLoad" => _INNER_DICT(
-        ("PSRBus", RELATION_1_TO_1) => "bus",
-        ("PSRDemand", RELATION_1_TO_1) => "demand",
-    ),
-    "PSRInterconnection" => _INNER_DICT(
-        ("PSRSystem", RELATION_FROM) => "no1",
-        ("PSRSystem", RELATION_TO) => "no2",
-    ),
-    # TODO:
-    # merge series an trafos
-    "PSRLinkDC" => _INNER_DICT(
-        ("PSRBus", RELATION_FROM) => "no1",
-        ("PSRBus", RELATION_TO) => "no2",
-    ),
-    "PSRSerie" => _INNER_DICT(
-        ("PSRBus", RELATION_FROM) => "no1",
-        ("PSRBus", RELATION_TO) => "no2",
-    ),
-    "PSRTransformer" => _INNER_DICT(
-        ("PSRBus", RELATION_FROM) => "no1",
-        ("PSRBus", RELATION_TO) => "no2",
-    ),
-    "PSRBus" => _INNER_DICT(
-        ("PSRArea", RELATION_1_TO_1) => "area",
-        ("PSRSystem", RELATION_1_TO_1) => "system",
-    ),
-    # TODO maybe rename?
-    "PSRGenerationConstraintData" => _INNER_DICT(
-        ("PSRSystem", RELATION_1_TO_1) => "system",
-        ("PSRThermalPlant", RELATION_1_TO_N) => "usinas",
-        ("PSRHydroPlant", RELATION_1_TO_N) => "usinas",
-        ("PSRGndPlant", RELATION_1_TO_N) => "usinas",
-        ("PSRBattery", RELATION_1_TO_N) => "batteries",
-    ),
-    # TODO maybe rename?
-    "PSRInterconnectionSumData" =>
-        _INNER_DICT(("PSRInterconnection", RELATION_1_TO_N) => "elements"),
-    # TODO maybe rename?
-    "PSRMaintenanceData" => _INNER_DICT(
-        ("PSRSystem", RELATION_1_TO_1) => "system",
-        ("PSRThermalPlant", RELATION_1_TO_1) => "plant",
-        ("PSRHydroPlant", RELATION_1_TO_1) => "plant",
-        ("PSRGndPlant", RELATION_1_TO_1) => "plant",
-    ),
-    # TODO maybe rename?
-    "PSRReserveGenerationConstraintData" => _INNER_DICT(
-        ("PSRSystem", RELATION_1_TO_1) => "system",
-        ("PSRThermalPlant", RELATION_1_TO_N) => "usinas",
-        ("PSRHydroPlant", RELATION_1_TO_N) => "usinas",
-        ("PSRGndPlant", RELATION_1_TO_N) => "usinas",
-        ("PSRBattery", RELATION_1_TO_N) => "batteries",
-        ("PSRThermalPlant", RELATION_BACKED) => "backed",
-        ("PSRHydroPlant", RELATION_BACKED) => "backed",
-        ("PSRGndPlant", RELATION_BACKED) => "backed",
-    ),
-    # TODO maybe rename?
-    "PSRReservoirSet" => _INNER_DICT(
-        ("PSRHydroPlant", RELATION_1_TO_N) => "reservoirs",
-    ),
-    "PSRPowerInjection" => _INNER_DICT(
-        ("PSRBus", RELATION_1_TO_1) => "bus",
-    ),
-)
+"""
+    _has_relation_attribute(relations::Vector{PMD.Relation}, relation_attribute::String)
 
-function _get_relation(source::String, target::String, relation_type::RelationType)
-    return _RELATIONS[source][(target, relation_type)]
+    Returns true if there is a relation with attribute 'relation_attribute' in a 'Vector{PMD.Relation}'
+"""
+function _has_relation_attribute(relations::Vector{PMD.Relation}, relation_attribute::String)
+    has_relation_attribute = false
+    for relation in relations
+        if relation.attribute == relation_attribute
+            has_relation_attribute = true
+        end
+    end
+    return has_relation_attribute
 end
 
+"""
+    _has_relation_type(relations::Vector{PMD.Relation}, relation_type::PMD.RelationType)
+
+    Returns true if there is a relation with type 'relation_type' in a 'Vector{PMD.Relation}'
+"""
+function _has_relation_type(relations::Vector{PMD.Relation}, relation_type::PMD.RelationType)
+    has_relation_type = false
+    for relation in relations
+        if relation.type == relation_type
+            has_relation_type = true
+        end
+    end
+    return has_relation_type
+end
+
+"""
+    _check_relation(data::Data, source::String)
+
+    Returns an error message if there is no relation where collection 'source' is the source element
+"""
+function validate_relation(data::Data, source::String)
+    if !haskey(data.relation_mapper, source)
+        error("Collection $(source) is not the source for any relation in this study")
+    end
+end
+
+"""
+    validate_relation(data::Data, source::String, target::String)
+
+    Returns an error message if there is no relation between collections 'source' and 'target'
+"""
+function validate_relation(data::Data, source::String, target::String)
+    validate_relation(data::Data, source::String)
+
+    if !haskey(data.relation_mapper[source], target)
+        if !haskey(data.relation_mapper, target) || !haskey(data.relation_mapper[target], source)
+            error("No relation from $source to $target.")
+        end
+        if haskey(data.relation_mapper, target) && haskey(data.relation_mapper[target], source)
+            error(
+                "No relation from $source to $target." *
+                "There is a reverse relation from $target to $source."
+            )
+        end
+    end
+end
+
+"""
+    validate_relation(data::Data, source::String, target::String, relation_type::PMD.RelationType)
+
+    Returns an error message if there is no relation between collections 'source' and 'target' with type 'relation_type'
+"""
+function validate_relation(data::Data, source::String, target::String, relation_type::PMD.RelationType)
+    validate_relation(data, source, target)
+
+    if !_has_relation_type(data.relation_mapper[source][target], relation_type)
+        if haskey(data.relation_mapper,target) && haskey(data.relation_mapper[target], source)
+            if _has_relation_type(data.relation_mapper[target][source], relation_type)
+                error(
+                    "No relation from $(source) to $(target) with type $(relation_type)." *
+                    " The there is a reverse relation from $(target) to " *
+                    "$(source)  with type $(relation_type)."
+                )
+            end
+        end
+        error("There is no relation with type $(relation_type) between collections $(source) and $(target)")
+    end
+end
+
+"""
+    validate_relation(data::Data, source::String, target::String, relation_attribute::String)
+
+    Returns an error message if there is no relation between collections 'source' and 'target' with attribute 'relation_attribute'
+"""
+function validate_relation(data::Data, source::String, target::String, relation_attribute::String)
+    validate_relation(data, source, target)
+
+    if !_has_relation_attribute(data.relation_mapper[source][target], relation_attribute)
+        if haskey(data.relation_mapper,target) && haskey(data.relation_mapper[target], source)
+            if _has_relation_attribute(data.relation_mapper[target][source], relation_attribute)
+                error(
+                    "No relation from $(source) to $(target) with attribute $(relation_attribute)." *
+                    " The there is a reverse relation from $(target) to " *
+                    "$(source)  with attribute $(relation_attribute)."
+                )
+            end
+        end
+        error("There is no relation with attribute $(relation_attribute) between collections $(source) and $(target)")
+    end
+end
+
+"""
+    _get_relation_attribute(data::Data, source::String, target::String, relation_type::PMD.RelationType)
+    
+    Returns the attribute that represents a relation between elements from collections 'source' and 'target'
+"""
+function _get_relation_attribute(data::Data, source::String, target::String, relation_type::PMD.RelationType)
+    
+    validate_relation(data, source, target, relation_type)
+
+    relations = data.relation_mapper[source][target]
+    attribute = ""
+
+    for relation in relations
+        if relation.type == relation_type
+            attribute = relation.attribute
+            break
+        end
+    end
+
+    return attribute
+end
+
+"""
+    _get_target_index_from_relation(
+        data::Data,
+        source::String,
+        source_index::Integer,
+        relation_attribute::String,
+    )
+    
+    Returns the 'target' element's index stored in 'source' element in the attribute 'relation_attribute'
+"""
 function _get_target_index_from_relation(
     data::Data,
     source::String,
@@ -141,6 +167,16 @@ function _get_target_index_from_relation(
     return target_indices
 end
 
+"""
+    _get_sources_indices_from_relations(
+        data::Data,
+        source::String,
+        target_id::Integer,
+        relation_attribute::String,
+    )
+    
+    Returns indices of all elements from collection 'source' that have an attribute 'relation_attribute' that stores the given 'target_id'
+"""
 function _get_sources_indices_from_relations(
     data::Data,
     source::String,
@@ -148,6 +184,18 @@ function _get_sources_indices_from_relations(
     target_id::Integer,
     relation_attribute::String,
 )
+    if target != first(_get_index(data.data_index, target_id))
+        error("Reference id $(target_id) is not for an element from collection $target")
+    end
+    validate_relation(data, source, target, relation_attribute)
+
+    if !haskey(data.raw, source)
+        return Vector{Int32}()
+    end
+    if !haskey(data.raw, target)
+        return Vector{Int32}()
+    end
+
     possible_elements = data.raw[source]
 
     indices = Vector{Int32}()
@@ -164,50 +212,83 @@ end
 function _get_element_related(data::Data, collection::String, index::Integer)
     element = _get_element(data, collection, index)
 
-    # source_collection, target_collection, source_index, target_index
-    relations = Dict{Tuple{String, String, Int, Int}, String}()
+    
+    relations_as_source = Dict{String, Dict{String,Vector{Int}}}() # Dict{target_collection, Dict{attribute, Vector{target_index}}}
+    relations_as_target = Dict{String, Dict{String,Vector{Int}}}() # Dict{source_collection, Dict{attribute, Vector{source_index}}}
 
     # Relations where the element is source
-    if haskey(_RELATIONS, collection)
-        for ((target, _), attribute) in _RELATIONS[collection]
-            if haskey(element, attribute) # has a relation as source
-                target_indices =
-                    _get_target_index_from_relation(data, collection, index, attribute)
-                for target_index in target_indices
-                    relations[(collection, target, index, target_index)] = attribute
-                end
-            end
-        end
-    end
-
-    # Relations where the element is target
-    for (source, _) in _RELATIONS
-        for ((target, _), attribute) in _RELATIONS[source]
-            if haskey(data.raw, source)
-                if target == collection
-                    sources_indices = _get_sources_indices_from_relations(
-                        data,
-                        source,
-                        target,
-                        element["reference_id"],
-                        attribute,
-                    )
-                    if !isempty(sources_indices)
-                        for source_index in sources_indices
-                            relations[(source, collection, source_index, index)] = attribute
-                        end
+    if haskey(data.relation_mapper, collection)
+        for (target, relations_vector) in data.relation_mapper[collection]
+            relations_as_source[target] = Dict{String, Vector{Int}}()
+            for relation in relations_vector
+                if haskey(element, relation.attribute) # has a relation as source
+                    target_indices =
+                        _get_target_index_from_relation(data, collection, index, relation.attribute)
+                    if !isempty(target_indices)
+                        relations_as_source[target][relation.attribute] = Vector{Int}()
+                        append!(relations_as_source[target][relation.attribute],target_indices)
                     end
                 end
             end
+            if isempty(relations_as_source[target])
+                delete!(relations_as_source, target)
+            end
         end
     end
-    return relations
+    
+    # Relations where the element is target
+    for (source, related) in data.relation_mapper
+        for (target, relations) in related
+            if haskey(data.raw, source) && target == collection
+                relations_as_target[source] = Dict{String, Vector{Int}}()
+                for relation in relations
+                    source_indices = _get_sources_indices_from_relations(
+                        data,
+                        source,
+                        collection,
+                        element["reference_id"],
+                        relation.attribute
+                    )
+                    if !isempty(source_indices)
+                        relations_as_target[source][relation.attribute] = Vector{Int}()
+                        append!(relations_as_target[source][relation.attribute], source_indices)
+                    end
+                end
+                if isempty(relations_as_target[source])
+                    delete!(relations_as_target, source)
+                end
+            end
+        end
+    end
+    
+    return relations_as_source, relations_as_target
 end
 
-function has_relations(data::Data, collection::String, index::Integer)
-    relations = _get_element_related(data, collection, index)
+"""
+    has_relations(data::Data, collection::String)
 
-    if !isempty(relations)
+    Returns true if collection 'collection' has any defined relation
+"""
+function has_relations(data::Data, collection::String)
+    if !haskey(data.relation_mapper, collection)
+        return false
+    end
+    return true
+end
+
+"""
+    has_relations(data::Data, collection::String, index::Integer)
+
+    Returns true if element of index 'index' from collection 'collection' has any defined relation
+"""
+function has_relations(data::Data, collection::String, index::Int)
+    if !haskey(data.relation_mapper, collection)
+        return false
+    end
+
+    relations_as_source, relations_as_target = _get_element_related(data, collection, index)
+
+    if !isempty(relations_as_source) || !isempty(relations_as_target)
         return true
     end
 
@@ -220,74 +301,37 @@ function relations_summary(data::Data, collection::String, index::Integer)
         return
     end
 
-    relations = _get_element_related(data, collection, index)
+    relations_as_source, relations_as_target = _get_element_related(data, collection, index)
 
-    for (
-        relation_index,
-        ((source_collection, target_collection, source_index, target_index), _),
-    ) in enumerate(relations)
-        if source_collection == collection && source_index == index
+    for (target, value) in relations_as_source
+        for (target_index, attribute) in value
             println(
-                "$relation_index: $source_collection[$source_index] → $target_collection[$target_index]",
-            )
-        else
-            println(
-                "$relation_index: $target_collection[$target_index] ← $source_collection[$source_index]",
+                "$attribute: $collection[$index] → $target[$target_index]",
             )
         end
     end
+
+    for (source, value) in relations_as_target
+        for (source_index, attribute) in value
+            println(
+                "$attribute: $source[$source_index] ← $collection[$index]",
+            )
+        end
+    end
+    
     return
 end
 
-function check_relation_scalar(relation_type)
+function check_relation_scalar(relation_type::PMD.RelationType)
     if is_vector_relation(relation_type)
         error("Relation of type $relation_type is of type vector, not the expected scalar.")
     end
     return nothing
 end
 
-function check_relation_vector(relation_type)
+function check_relation_vector(relation_type::PMD.RelationType)
     if !is_vector_relation(relation_type)
         error("Relation of type $relation_type is of type scalar, not the expected vector.")
-    end
-    return nothing
-end
-
-function validate_relation(lst_from::String, lst_to::String, type::RelationType)
-    direct = false
-    reverse = false
-    reverse_type = nothing
-    if haskey(_RELATIONS, lst_from)
-        direct = true # there are relations from lst_from
-        if haskey(_RELATIONS[lst_from], (lst_to, type))
-            return nothing # valid relation found
-        end
-    end
-    if haskey(_RELATIONS, lst_to)
-        for (k, v) in _RELATIONS[lst_to]
-            if k[1] == lst_from
-                reverse = true # a reverse relation was found
-                reverse_type = k[2]
-                break
-            end
-        end
-    end
-    if reverse
-        error(
-            "No relation from $lst_from to $lst_to with type $type." *
-            " The there is a reverse relation from $lst_to to " *
-            "$lst_from  with type $type.\n" *
-            "Try: PSRI.get_reverse_vector_map(data, \"$lst_to\", " *
-            "\"$lst_from\"; original_relation_type = $(reverse_type))",
-        )
-    elseif direct
-        error(
-            "No relation from $lst_from to $lst_to with type $type \n" *
-            "Available relations from $lst_from are: \n" *
-            "$(keys(_RELATIONS[lst_from]))",
-        )
-    else
-        error("No relations from $lst_from available")
     end
     return nothing
 end
@@ -297,7 +341,7 @@ function get_reverse_map(
     lst_from::String,
     lst_to::String;
     allow_empty::Bool = true,
-    original_relation_type::RelationType = RELATION_1_TO_1, # type of the direct relation
+    original_relation_type::PMD.RelationType = PMD.RELATION_1_TO_1, # type of the direct relation
 )
     n_to = max_elements(data, lst_to)
     if n_to == 0
@@ -352,7 +396,7 @@ function get_reverse_vector_map(
     lst_from::String,
     lst_to::String;
     allow_empty::Bool = true,
-    original_relation_type::RelationType = RELATION_1_TO_N,
+    original_relation_type::PMD.RelationType = RELATION_1_TO_N,
 )
     n_to = max_elements(data, lst_to)
     if n_to == 0
@@ -395,12 +439,12 @@ function get_map(
     lst_from::String,
     lst_to::String;
     allow_empty::Bool = true,
-    relation_type::RelationType = RELATION_1_TO_1, # type of the direct relation
+    relation_type::PMD.RelationType = PMD.RELATION_1_TO_1, # type of the direct relation
 )
     if is_vector_relation(relation_type)
         error("For relation relation_type = $relation_type use get_vector_map")
     end
-    validate_relation(lst_from, lst_to, relation_type)
+    validate_relation(data, lst_from, lst_to, relation_type)
 
     # @assert TYPE == PSR_RELATIONSHIP_1TO1 # TODO I think we don't need that in this interface
     raw = _raw(data)
@@ -414,7 +458,7 @@ function get_map(
         return zeros(Int32, n_from)
     end
 
-    raw_field = _get_relation(lst_from, lst_to, relation_type)
+    raw_field = _get_relation_attribute(data, lst_from, lst_to, relation_type)
 
     out = zeros(Int32, n_from)
 
@@ -423,6 +467,7 @@ function get_map(
 
     # TODO improve this quadratic loop
     for (idx_from, el_from) in enumerate(vec_from)
+
         id_to = get(el_from, raw_field, -1)
 
         found = false
@@ -437,6 +482,7 @@ function get_map(
         if !found && !allow_empty
             error("No $lst_to element matching $lst_from of index $idx_from")
         end
+
     end
     return out
 end
@@ -446,13 +492,13 @@ function get_vector_map(
     lst_from::String,
     lst_to::String;
     allow_empty::Bool = true,
-    relation_type::RelationType = RELATION_1_TO_N,
+    relation_type::PMD.RelationType = PMD.RELATION_1_TO_N,
 )
     if !is_vector_relation(relation_type)
         error("For relation relation_type = $relation_type use get_map")
     end
 
-    validate_relation(lst_from, lst_to, relation_type)
+    validate_relation(data, lst_from, lst_to, relation_type)
 
     # @assert TYPE == PSR_RELATIONSHIP_1TO1 # TODO I think we don't need that in this interface
     raw = _raw(data)
@@ -466,7 +512,7 @@ function get_vector_map(
         return Vector{Int32}[Int32[] for _ in 1:n_from]
     end
 
-    raw_field = _get_relation(lst_from, lst_to, relation_type)
+    raw_field = _get_relation_attribute(data, lst_from, lst_to, relation_type)
 
     out = Vector{Int32}[Int32[] for _ in 1:n_from]
 
@@ -499,11 +545,11 @@ function get_related(
     source::String,
     target::String,
     source_index::Integer;
-    relation_type::RelationType = RELATION_1_TO_1,
+    relation_type::PMD.RelationType = PMD.RelationType.RELATION_1_TO_1,
 )
     check_relation_scalar(relation_type)
-    validate_relation(source, target, relation_type)
-    relation_field = _get_relation(source, target, relation_type)
+    validate_relation(data, source, target, relation_type)
+    relation_field = _get_relation_attribute(data, source, target, relation_type)
     source_element = _get_element(data, source, source_index)
 
     if !haskey(source_element, relation_field)
@@ -532,12 +578,12 @@ function get_vector_related(
     source::String,
     target::String,
     source_index::Integer,
-    relation_type::RelationType = RELATION_1_TO_N,
+    relation_type::PMD.RelationType = RELATION_1_TO_N,
 )
     check_relation_vector(relation_type)
-    validate_relation(source, target, relation_type)
+    validate_relation(data, source, target, relation_type)
     source_element = _get_element(data, source, source_index)
-    relation_field = _get_relation(source, target, relation_type)
+    relation_field = _get_relation_attribute(data, source, target, relation_type)
 
     if !haskey(source_element, relation_field)
         error(

--- a/src/OpenStudy/relations.jl
+++ b/src/OpenStudy/relations.jl
@@ -209,6 +209,16 @@ function _get_sources_indices_from_relations(
     return indices
 end
 
+"""
+    _get_element_related(data::Data, collection::String, index::Integer)
+    
+    Returns two dictionaries:
+    - Dict{target_collection, Dict{attribute, Vector{target_index}}}
+    - Dict{source_collection, Dict{attribute, Vector{source_index}}}
+
+    The first contains information about the relations that the element has with the role of source in a study.
+    The second, information about the relations that the element has with the role of target in a study.
+"""
 function _get_element_related(data::Data, collection::String, index::Integer)
     element = _get_element(data, collection, index)
 
@@ -295,6 +305,15 @@ function has_relations(data::Data, collection::String, index::Int)
     return false
 end
 
+"""
+    relations_summary(data::Data, collection::String, index::Integer)
+
+    Displays all current relations of the element in the following way:
+
+    attribute_name: collection_name[element_index] → collection_name[element_index]
+
+    (The arrow always points from the source to target)
+"""
 function relations_summary(data::Data, collection::String, index::Integer)
     if !has_relations(data, collection, index)
         println("This element does not have any relations")
@@ -304,15 +323,15 @@ function relations_summary(data::Data, collection::String, index::Integer)
     relations_as_source, relations_as_target = _get_element_related(data, collection, index)
 
     for (target, value) in relations_as_source
-        for (target_index, attribute) in value
+        for (attribute, target_index) in value
             println(
-                "$attribute: $collection[$index] → $target[$target_index]",
+                "$attribute: $collection[$index] → $target$target_index",
             )
         end
     end
 
     for (source, value) in relations_as_target
-        for (source_index, attribute) in value
+        for (attribute, source_index) in value
             println(
                 "$attribute: $source[$source_index] ← $collection[$index]",
             )
@@ -322,6 +341,12 @@ function relations_summary(data::Data, collection::String, index::Integer)
     return
 end
 
+
+"""
+    check_relation_scalar(relation_type::PMD.RelationType)
+
+    Returns an error message if relation_type is not a scalar
+"""
 function check_relation_scalar(relation_type::PMD.RelationType)
     if is_vector_relation(relation_type)
         error("Relation of type $relation_type is of type vector, not the expected scalar.")
@@ -329,6 +354,11 @@ function check_relation_scalar(relation_type::PMD.RelationType)
     return nothing
 end
 
+"""
+    check_relation_vector(relation_type::PMD.RelationType)
+
+    Returns an error message if relation_type is not a vector
+"""
 function check_relation_vector(relation_type::PMD.RelationType)
     if !is_vector_relation(relation_type)
         error("Relation of type $relation_type is of type scalar, not the expected vector.")
@@ -545,7 +575,7 @@ function get_related(
     source::String,
     target::String,
     source_index::Integer;
-    relation_type::PMD.RelationType = PMD.RelationType.RELATION_1_TO_1,
+    relation_type::PMD.RelationType = PMD.RELATION_1_TO_1,
 )
     check_relation_scalar(relation_type)
     validate_relation(data, source, target, relation_type)
@@ -578,7 +608,7 @@ function get_vector_related(
     source::String,
     target::String,
     source_index::Integer,
-    relation_type::PMD.RelationType = RELATION_1_TO_N,
+    relation_type::PMD.RelationType = PMD.RELATION_1_TO_N,
 )
     check_relation_vector(relation_type)
     validate_relation(data, source, target, relation_type)

--- a/src/OpenStudy/study_openinterface.jl
+++ b/src/OpenStudy/study_openinterface.jl
@@ -276,7 +276,7 @@ function initialize_study(
 
     relation_mapper = PMD.RelationMapper()
 
-    PMD.load_relations_struct!(relations_defaults_path ,relation_mapper)
+    PMD.load_relations_struct!(relations_defaults_path, relation_mapper)
 
     data_struct, model_files_added = PMD.load_model(path_pmds, pmd_files, model_template)
 
@@ -343,7 +343,7 @@ function initialize_study(
         log_file = log_file,
         verbose = verbose,
         model_template = model_template,
-        relation_mapper = relation_mapper
+        relation_mapper = relation_mapper,
     )
 
     if add_transformers_to_series

--- a/src/OpenStudy/study_openinterface.jl
+++ b/src/OpenStudy/study_openinterface.jl
@@ -150,6 +150,9 @@ Base.@kwdef mutable struct Data{T} <: AbstractData
     # Model Templates 
     model_template::PMD.ModelTemplate = PMD.ModelTemplate()
 
+    # Relations
+    relation_mapper::PMD.RelationMapper
+
     # ReaderMapper
     mapper::Union{ReaderMapper, Nothing} = nothing
 end
@@ -231,6 +234,7 @@ function initialize_study(
     validate_attributes::Bool = true,
     _netplan_database::Bool = false,
     model_template_path::Union{String, Nothing} = nothing,
+    relations_defaults_path = PMD._DEFAULT_RELATIONS_PATH,
     #merge collections
     add_transformers_to_series::Bool = true,
     #json api 
@@ -269,6 +273,10 @@ function initialize_study(
     else
         PMD.load_model_template!(model_template_path, model_template)
     end
+
+    relation_mapper = PMD.RelationMapper()
+
+    PMD.load_relations_struct!(relations_defaults_path ,relation_mapper)
 
     data_struct, model_files_added = PMD.load_model(path_pmds, pmd_files, model_template)
 
@@ -335,6 +343,7 @@ function initialize_study(
         log_file = log_file,
         verbose = verbose,
         model_template = model_template,
+        relation_mapper = relation_mapper
     )
 
     if add_transformers_to_series

--- a/src/PMD/PMD.jl
+++ b/src/PMD/PMD.jl
@@ -26,6 +26,7 @@ end
 const DataStruct = Dict{String, Dict{String, Attribute}}
 
 include("model_template.jl")
+include("relation_mapper.jl")
 
 const _PMDS_BASE_PATH = joinpath(@__DIR__(), "pmds")
 

--- a/src/PMD/relation_mapper.jl
+++ b/src/PMD/relation_mapper.jl
@@ -1,0 +1,62 @@
+using JSON
+
+const _DEFAULT_RELATIONS_PATH = joinpath(@__DIR__(), "..", "json_metadata", "relations.default.json")
+
+"""
+    RelationType
+
+Possible relation types used in mapping function such as [`get_map`](@ref), [`get_reverse_map`](@ref), etc.
+
+The current possible relation types are:
+
+```julia
+RELATION_1_TO_1
+RELATION_1_TO_N
+RELATION_FROM
+RELATION_TO
+RELATION_TURBINE_TO
+RELATION_SPILL_TO
+RELATION_INFILTRATE_TO
+RELATION_STORED_ENERGY_DONWSTREAM
+RELATION_BACKED
+```
+"""
+@enum RelationType begin
+    RELATION_1_TO_1 = 0
+    RELATION_1_TO_N = 1
+    RELATION_FROM   = 2
+    RELATION_TO     = 3
+    RELATION_TURBINE_TO = 4
+    RELATION_SPILL_TO   = 5
+    RELATION_INFILTRATE_TO = 6
+    RELATION_STORED_ENERGY_DONWSTREAM = 7
+    RELATION_BACKED = 8
+end
+
+"""
+```
+struct Relation
+    target_collection::String
+    type::RelationType
+    attribute::String
+end
+```
+"""
+struct Relation
+    type::RelationType
+    attribute::String
+end
+
+const RelationMapper = Dict{String, Dict{String, Vector{Relation}}}
+
+function load_relations_struct!(path::AbstractString, relation_mapper::RelationMapper)
+    raw_struct = JSON.parsefile(path)
+
+    for (key, value) in raw_struct
+        relation_mapper[key] = Dict{String, Vector{Relation}}()
+        for (collection, relations) in value
+            relations_vector = [Relation(RelationType(relation["type"]),relation["attribute"]) for relation in relations]
+            relation_mapper[key][collection] = relations_vector
+        end
+    end
+end

--- a/src/PMD/relation_mapper.jl
+++ b/src/PMD/relation_mapper.jl
@@ -1,6 +1,7 @@
 using JSON
 
-const _DEFAULT_RELATIONS_PATH = joinpath(@__DIR__(), "..", "json_metadata", "relations.default.json")
+const _DEFAULT_RELATIONS_PATH =
+    joinpath(@__DIR__(), "..", "json_metadata", "relations.default.json")
 
 """
     RelationType
@@ -24,10 +25,10 @@ RELATION_BACKED
 @enum RelationType begin
     RELATION_1_TO_1 = 0
     RELATION_1_TO_N = 1
-    RELATION_FROM   = 2
-    RELATION_TO     = 3
+    RELATION_FROM = 2
+    RELATION_TO = 3
     RELATION_TURBINE_TO = 4
-    RELATION_SPILL_TO   = 5
+    RELATION_SPILL_TO = 5
     RELATION_INFILTRATE_TO = 6
     RELATION_STORED_ENERGY_DONWSTREAM = 7
     RELATION_BACKED = 8
@@ -55,7 +56,10 @@ function load_relations_struct!(path::AbstractString, relation_mapper::RelationM
     for (key, value) in raw_struct
         relation_mapper[key] = Dict{String, Vector{Relation}}()
         for (collection, relations) in value
-            relations_vector = [Relation(RelationType(relation["type"]),relation["attribute"]) for relation in relations]
+            relations_vector = [
+                Relation(RelationType(relation["type"]), relation["attribute"]) for
+                relation in relations
+            ]
             relation_mapper[key][collection] = relations_vector
         end
     end

--- a/src/json_metadata/relations.default.json
+++ b/src/json_metadata/relations.default.json
@@ -1,0 +1,356 @@
+{
+    "PSRThermalPlant": {
+        "PSRFuel": [
+            {
+                "type": 1,
+                "attribute": "fuels"
+            }
+        ],
+        "PSRSystem": [
+            {
+                "type": 0,
+                "attribute": "system"
+            }
+        ]
+    },
+    "PSRFuelConsumption": {
+        "PSRFuel": [
+            {
+                "type": 0,
+                "attribute": "fuel"
+            }
+        ],
+        "PSRThermalPlant": [
+            {
+                "type": 0,
+                "attribute": "plant"
+            }
+        ]
+    },
+    "PSRHydroPlant": {
+        "PSRGaugingStation": [
+            {
+                "type": 0,
+                "attribute": "station"
+            }
+        ],
+        "PSRSystem": [
+            {
+                "type": 0,
+                "attribute": "system"
+            }
+        ],
+        "PSRHydroPlant": [
+            {
+                "type": 4,
+                "attribute": "turbinning"
+            },
+            {
+                "type": 5,
+                "attribute": "spilling"
+            },
+            {
+                "type": 6,
+                "attribute": "filtration"
+            },
+            {
+                "type": 7,
+                "attribute": "storedenergy"
+            }
+        ]
+    },
+    "PSRGndPlant": {
+        "PSRGaugingStation": [
+            {
+                "type": 0,
+                "attribute": "station"
+            }
+        ],
+        "PSRSystem": [
+            {
+                "type": 0,
+                "attribute": "system"
+            }
+        ]
+    },
+    "PSRGaugingStation": {
+        "PSRGaugingStation": [
+            {
+                "type": 0,
+                "attribute": "downstream"
+            }
+        ]
+    },
+    "PSRBattery": {
+        "PSRBus": [
+            {
+                "type": 0,
+                "attribute": "bus"
+            }
+        ],
+        "PSRSystem": [
+            {
+                "type": 0,
+                "attribute": "system"
+            }
+        ]
+    },
+    "PSRGenerator": {
+        "PSRBus": [
+            {
+                "type": 0,
+                "attribute": "bus"
+            }
+        ],
+        "PSRThermalPlant": [
+            {
+                "type": 0,
+                "attribute": "plant"
+            }
+        ],
+        "PSRHydroPlant": [
+            {
+                "type": 0,
+                "attribute": "plant"
+            }
+        ],
+        "PSRGndPlant": [
+            {
+                "type": 0,
+                "attribute": "plant"
+            }
+        ]
+    },
+    "PSRFuel": {
+        "PSRSystem": [
+            {
+                "type": 0,
+                "attribute": "system"
+            }
+        ]
+    },
+    "PSRDemandSegment": {
+        "PSRDemand": [
+            {
+                "type": 0,
+                "attribute": "demand"
+            }
+        ],
+        "PSRSystem": [
+            {
+                "type": 0,
+                "attribute": "system"
+            }
+        ]
+    },
+    "PSRDemand": {
+        "PSRSystem": [
+            {
+                "type": 0,
+                "attribute": "system"
+            }
+        ]
+    },
+    "PSRLoad": {
+        "PSRBus": [
+            {
+                "type": 0,
+                "attribute": "bus"
+            }
+        ],
+        "PSRDemand": [
+            {
+                "type": 0,
+                "attribute": "demand"
+            }
+        ]
+    },
+    "PSRInterconnection": {
+        "PSRSystem": [
+            {
+                "type": 2,
+                "attribute": "no1"
+            },
+            {
+                "type": 3,
+                "attribute": "no2"
+            }
+        ]
+    },
+    "PSRLinkDC": {
+        "PSRBus": [
+            {
+                "type": 2,
+                "attribute": "no1"
+            },
+            {
+                "type": 3,
+                "attribute": "no2"
+            }
+        ]
+    },
+    "PSRSerie": {
+        "PSRBus": [
+            {
+                "type": 2,
+                "attribute": "no1"
+            },
+            {
+                "type": 3,
+                "attribute": "no2"
+            }
+        ]
+    },
+    "PSRTransformer": {
+        "PSRBus": [
+            {
+                "type": 2,
+                "attribute": "no1"
+            },
+            {
+                "type": 3,
+                "attribute": "no2"
+            }
+        ]
+    },
+    "PSRBus": {
+        "PSRArea": [
+            {
+                "type": 0,
+                "attribute": "area"
+            }
+        ],
+        "PSRSystem": [
+            {
+                "type": 0,
+                "attribute": "system"
+            }
+        ]
+    },
+    "PSRGenerationConstraintData": {
+        "PSRSystem": [
+            {
+                "type": 0,
+                "attribute": "system"
+            }
+        ],
+        "PSRThermalPlant": [
+            {
+                "type": 1,
+                "attribute": "usinas"
+            }
+        ],
+        "PSRHydroPlant": [
+            {
+                "type": 1,
+                "attribute": "usinas"
+            }
+        ],
+        "PSRGndPlant": [
+            {
+                "type": 1,
+                "attribute": "usinas"
+            }
+        ],
+        "PSRBattery": [
+            {
+                "type": 1,
+                "attribute": "batteries"
+            }
+        ]
+    },
+    "PSRInterconnectionSumData": {
+        "PSRInterconnection": [
+            {
+                "type": 1,
+                "attribute": "elements"
+            }
+        ]
+    },
+    "PSRMaintenanceData": {
+        "PSRSystem": [
+            {
+                "type": 0,
+                "attribute": "system"
+            }
+        ],
+        "PSRThermalPlant": [
+            {
+                "type": 0,
+                "attribute": "plant"
+            }
+        ],
+        "PSRHydroPlant": [
+            {
+                "type": 0,
+                "attribute": "plant"
+            }
+        ],
+        "PSRGndPlant": [
+            {
+                "type": 0,
+                "attribute": "plant"
+            }
+        ]
+    },
+    "PSRReserveGenerationConstraintData": {
+        "PSRSystem": [
+            {
+                "type": 0,
+                "attribute": "system"
+            }
+        ],
+        "PSRThermalPlant": [
+            {
+                "type": 1,
+                "attribute": "usinas"
+            },
+            {
+                "type": 8,
+                "attribute": "backed"
+            }
+        ],
+        "PSRHydroPlant": [
+            {
+                "type": 1,
+                "attribute": "usinas"
+            },
+            {
+                "type": 8,
+                "attribute": "backed"
+            }
+        ],
+        "PSRGndPlant": [
+            {
+                "type": 1,
+                "attribute": "usinas"
+            },
+            {
+                "type": 8,
+                "attribute": "backed"
+            }
+        ],
+        "PSRBattery": [
+            {
+                "type": 1,
+                "attribute": "batteries"
+            }
+        ]
+    },
+    "PSRReservoirSet": {
+        "PSRHydroPlant": [
+            {
+                "type": 1,
+                "attribute": "reservoirs"
+            }
+        ]
+    },
+    "PSRPowerInjection": {
+        "PSRBus": [
+            {
+                "type": 0,
+                "attribute": "bus"
+            }
+        ]
+    }
+}

--- a/src/modification_api.jl
+++ b/src/modification_api.jl
@@ -299,11 +299,11 @@ function set_related!(
     target::String,
     source_index::Integer,
     target_index::Integer;
-    relation_type::RelationType = RELATION_1_TO_1,
+    relation_type::PMD.RelationType = PMD.RELATION_1_TO_1,
 )
     check_relation_scalar(relation_type)
-    validate_relation(source, target, relation_type)
-    relation_field = _get_relation(source, target, relation_type)
+    validate_relation(data, source, target, relation_type)
+    relation_field = _get_relation_attribute(data, source, target, relation_type)
     source_element = _get_element(data, source, source_index)
     target_element = _get_element(data, target, target_index)
 
@@ -318,7 +318,7 @@ function set_related_by_code!(
     target::String,
     source_index::Integer,
     target_code::Integer;
-    relation_type::RelationType = RELATION_1_TO_1,
+    relation_type::PMD.RelationType = PMD.RELATION_1_TO_1,
 )
     target_index = _get_index_by_code(data, target, target_code)
     return set_related!(
@@ -337,12 +337,12 @@ function set_vector_related!(
     target::String,
     source_index::Integer,
     target_indices::Vector{T},
-    relation_type::RelationType = RELATION_1_TO_N,
+    relation_type::PMD.RelationType = PMD.RELATION_1_TO_N,
 ) where {T <: Integer}
     check_relation_vector(relation_type)
-    validate_relation(source, target, relation_type)
+    validate_relation(data, source, target, relation_type)
     source_element = _get_element(data, source, source_index)
-    relation_field = _get_relation(source, target, relation_type)
+    relation_field = _get_relation_attribute(data, source, target, relation_type)
 
     source_element[relation_field] = Int[]
     for target_index in target_indices
@@ -360,20 +360,19 @@ function delete_relation!(
     source_index::Integer,
     target_index::Integer,
 )
-    source_relations = _get_element_related(data, source, source_index)
-    if haskey(source_relations, (source, target, source_index, target_index))
-        relation_attribute = source_relations[(source, target, source_index, target_index)]
-        source_element = _get_element(data, source, source_index)
+    relations_as_source, _  = _get_element_related(data, source, source_index)
 
-        target_indices =
-            _get_target_index_from_relation(data, source, source_index, relation_attribute)
-        if length(target_indices) > 1
-            deleteat!(source_element[relation_attribute], target_indices .== target_index)
-        else
-            delete!(source_element, relation_attribute)
+    source_element = _get_element(data, source, source_index)
+    target_element = _get_element(data, target, target_index)
+
+    if haskey(relations_as_source, target)
+        for (relation_attribute, _) in relations_as_source[target]
+            if source_element[relation_attribute] == target_element["reference_id"]
+                delete!(source_element, relation_attribute)
+            end
         end
     else
-        error("Relation '$source'(Source) with '$target'(Target) does not exist")
+        error("Relation between element from '$source'(Source) with element from '$target'(Target) does not exist")
     end
 
     return nothing
@@ -386,13 +385,20 @@ function delete_vector_relation!(
     source_index::Integer,
     target_indices::Vector{Int},
 )
-    source_relations = _get_element_related(data, source, source_index)
-
-    relation_attribute = source_relations[(source, target, source_index, target_indices[1])]
+    relations_as_source, _ = _get_element_related(data, source, source_index)
 
     source_element = _get_element(data, source, source_index)
+    targets_ref_id = [_get_element(data, target, target_index)["reference_id"] for target_index in target_indices]
 
-    delete!(source_element, relation_attribute)
+    if haskey(relations_as_source, target)
+        for (relation_attribute, _) in relations_as_source[target]
+            if sort(source_element[relation_attribute]) == sort(targets_ref_id)
+                delete!(source_element, relation_attribute)
+            end
+        end
+    else
+        error("Relation between element from '$source'(Source) with element from '$target'(Target) does not exist")
+    end
 
     return nothing
 end
@@ -410,6 +416,7 @@ function create_study(
     defaults::Union{Dict{String, Any}, Nothing} = _load_defaults!(),
     netplan::Bool = false,
     model_template_path::Union{String, Nothing} = nothing,
+    relations_defaults_path = PMD._DEFAULT_RELATIONS_PATH,
     study_collection::String = "PSRStudy",
 )
     if !isdir(data_path)
@@ -445,6 +452,10 @@ function create_study(
     else
         PMD.load_model_template!(model_template_path, model_template)
     end
+
+    relation_mapper = PMD.RelationMapper()
+
+    PMD.load_relations_struct!(relations_defaults_path ,relation_mapper)
 
     data_struct, model_files_added = PMD.load_model(pmds_path, pmd_files, model_template)
 
@@ -510,6 +521,7 @@ function create_study(
         log_file = nothing,
         verbose = true,
         model_template = model_template,
+        relation_mapper = relation_mapper
     )
 
     _create_study_collection(data, study_collection, study_defaults)

--- a/src/modification_api.jl
+++ b/src/modification_api.jl
@@ -360,7 +360,7 @@ function delete_relation!(
     source_index::Integer,
     target_index::Integer,
 )
-    relations_as_source, _  = _get_element_related(data, source, source_index)
+    relations_as_source, _ = _get_element_related(data, source, source_index)
 
     source_element = _get_element(data, source, source_index)
     target_element = _get_element(data, target, target_index)
@@ -372,7 +372,9 @@ function delete_relation!(
             end
         end
     else
-        error("Relation between element from '$source'(Source) with element from '$target'(Target) does not exist")
+        error(
+            "Relation between element from '$source'(Source) with element from '$target'(Target) does not exist",
+        )
     end
 
     return nothing
@@ -388,7 +390,10 @@ function delete_vector_relation!(
     relations_as_source, _ = _get_element_related(data, source, source_index)
 
     source_element = _get_element(data, source, source_index)
-    targets_ref_id = [_get_element(data, target, target_index)["reference_id"] for target_index in target_indices]
+    targets_ref_id = [
+        _get_element(data, target, target_index)["reference_id"] for
+        target_index in target_indices
+    ]
 
     if haskey(relations_as_source, target)
         for (relation_attribute, _) in relations_as_source[target]
@@ -397,7 +402,9 @@ function delete_vector_relation!(
             end
         end
     else
-        error("Relation between element from '$source'(Source) with element from '$target'(Target) does not exist")
+        error(
+            "Relation between element from '$source'(Source) with element from '$target'(Target) does not exist",
+        )
     end
 
     return nothing
@@ -455,7 +462,7 @@ function create_study(
 
     relation_mapper = PMD.RelationMapper()
 
-    PMD.load_relations_struct!(relations_defaults_path ,relation_mapper)
+    PMD.load_relations_struct!(relations_defaults_path, relation_mapper)
 
     data_struct, model_files_added = PMD.load_model(pmds_path, pmd_files, model_template)
 
@@ -521,7 +528,7 @@ function create_study(
         log_file = nothing,
         verbose = true,
         model_template = model_template,
-        relation_mapper = relation_mapper
+        relation_mapper = relation_mapper,
     )
 
     _create_study_collection(data, study_collection, study_defaults)

--- a/src/study_interface.jl
+++ b/src/study_interface.jl
@@ -244,7 +244,12 @@ PSRI.get_map(
     "PSRHydroPlant";
     relation_type = PSRI.PMD.RELATION_TURBINE_TO,
 )
-PSRI.get_map(data, "PSRHydroPlant", "PSRHydroPlant"; relation_type = PSRI.PMD.RELATION_SPILL_TO)
+PSRI.get_map(
+    data,
+    "PSRHydroPlant",
+    "PSRHydroPlant";
+    relation_type = PSRI.PMD.RELATION_SPILL_TO,
+)
 PSRI.get_map(
     data,
     "PSRHydroPlant",

--- a/src/study_interface.jl
+++ b/src/study_interface.jl
@@ -5,37 +5,6 @@
 end
 
 """
-    RelationType
-
-Possible relation types used in mapping function such as [`get_map`](@ref), [`get_reverse_map`](@ref), etc.
-
-The current possible relation types are:
-
-```julia
-RELATION_1_TO_1
-RELATION_1_TO_N
-RELATION_FROM
-RELATION_TO
-RELATION_TURBINE_TO
-RELATION_SPILL_TO
-RELATION_INFILTRATE_TO
-RELATION_STORED_ENERGY_DONWSTREAM
-RELATION_BACKED
-```
-"""
-@enum RelationType begin
-    RELATION_1_TO_1
-    RELATION_1_TO_N
-    RELATION_FROM
-    RELATION_TO
-    RELATION_TURBINE_TO
-    RELATION_SPILL_TO
-    RELATION_INFILTRATE_TO
-    RELATION_STORED_ENERGY_DONWSTREAM
-    RELATION_BACKED
-end
-
-"""
     AbstractData
 """
 abstract type AbstractData end
@@ -273,33 +242,33 @@ PSRI.get_map(
     data,
     "PSRHydroPlant",
     "PSRHydroPlant";
-    relation_type = PSRI.RELATION_TURBINE_TO,
+    relation_type = PSRI.PMD.RELATION_TURBINE_TO,
 )
-PSRI.get_map(data, "PSRHydroPlant", "PSRHydroPlant"; relation_type = PSRI.RELATION_SPILL_TO)
+PSRI.get_map(data, "PSRHydroPlant", "PSRHydroPlant"; relation_type = PSRI.PMD.RELATION_SPILL_TO)
 PSRI.get_map(
     data,
     "PSRHydroPlant",
     "PSRHydroPlant";
-    relation_type = PSRI.RELATION_INFILTRATE_TO,
+    relation_type = PSRI.PMD.RELATION_INFILTRATE_TO,
 )
 PSRI.get_map(
     data,
     "PSRHydroPlant",
     "PSRHydroPlant";
-    relation_type = PSRI.RELATION_STORED_ENERGY_DONWSTREAM,
+    relation_type = PSRI.PMD.RELATION_STORED_ENERGY_DONWSTREAM,
 )
 
 @test PSRI.get_map(
     data,
     "PSRInterconnection",
     "PSRSystem",
-    relation_type = PSRI.RELATION_FROM,
+    relation_type = PSRI.PMD.RELATION_FROM,
 )
 @test PSRI.get_map(
     data,
     "PSRInterconnection",
     "PSRSystem",
-    relation_type = PSRI.RELATION_TO,
+    relation_type = PSRI.PMD.RELATION_TO,
 )
 ```
 """
@@ -328,7 +297,7 @@ PSRI.get_vector_map(
     data,
     "PSRReserveGenerationConstraintData",
     "PSRThermalPlant";
-    relation_type = PSRI.RELATION_BACKED,
+    relation_type = PSRI.PMD.RELATION_BACKED,
 )
 ```
 """
@@ -387,21 +356,21 @@ PSRI.get_reverse_vector_map(
     data,
     "PSRHydroPlant",
     "PSRHydroPlant";
-    original_relation_type = PSRI.RELATION_TURBINE_TO,
+    original_relation_type = PSRI.PMD.RELATION_TURBINE_TO,
 )
 # which is the reverse of
 PSRI.get_map(
     data,
     "PSRHydroPlant",
     "PSRHydroPlant";
-    relation_type = PSRI.RELATION_TURBINE_TO,
+    relation_type = PSRI.PMD.RELATION_TURBINE_TO,
 )
 
 PSRI.get_reverse_vector_map(
     data,
     "PSRGenerator",
     "PSRBus";
-    original_relation_type = PSRI.RELATION_1_TO_1,
+    original_relation_type = PSRI.PMD.RELATION_1_TO_1,
 )
 # which is the reverse of
 PSRI.get_map(data, "PSRGenerator", "PSRBus")
@@ -1227,22 +1196,14 @@ end
 """
     get_relations(data::AbstractData, collection::String)
 
-Returns a `Vector{Tuple{String, RelationType}}` with relating `collection`
+Returns a `Tuple{String, Vector{PMD.Relation}}` with relating `collection`
 and their relation type associated to `collection`.
 """
-function get_relations(::AbstractData, collection::String)
-    return get_relations(collection)
-end
-
-function get_relations(::DataStruct, collection::String)
-    return get_relations(collection)
-end
-
-function get_relations(collection::String)
-    if haskey(_RELATIONS, collection)
-        return collect(keys(_RELATIONS[collection]))
+function get_relations(data::AbstractData, collection::String)
+    if has_relations(data, collection)
+        return data.relation_mapper[collection]
     end
-    return Tuple{String, RelationType}[]
+    return Dict{String, Vector{PMD.Relation}}[]
 end
 
 """

--- a/test/loop_file.jl
+++ b/test/loop_file.jl
@@ -114,12 +114,20 @@ for col in collections
                 println("Relation: ($col)-($target) of type $(relation.type)")
             end
             if PSRI.is_vector_relation(relation.type)
-                parm_json = PSRI.get_vector_map(data, col, target; relation_type = relation.type)[json_to_bin]
-                parm_bin = PSRI.get_vector_map(data_bin, col, target; relation_type = relation.type)
+                parm_json =
+                    PSRI.get_vector_map(data, col, target; relation_type = relation.type)[json_to_bin]
+                parm_bin = PSRI.get_vector_map(
+                    data_bin,
+                    col,
+                    target;
+                    relation_type = relation.type,
+                )
                 @assert parm_json == parm_bin
             else
-                parm_json = PSRI.get_map(data, col, target; relation_type = relation.type)[json_to_bin]
-                parm_bin = PSRI.get_map(data_bin, col, target; relation_type = relation.type)
+                parm_json =
+                    PSRI.get_map(data, col, target; relation_type = relation.type)[json_to_bin]
+                parm_bin =
+                    PSRI.get_map(data_bin, col, target; relation_type = relation.type)
                 @assert parm_json == parm_bin
             end
         end

--- a/test/loop_file.jl
+++ b/test/loop_file.jl
@@ -108,18 +108,20 @@ for col in collections
         end
     end
     relations = PSRI.get_relations(data, col)
-    for (rel, tp) in relations
-        if verbose
-            println("    Relation: $rel of type $tp")
-        end
-        if PSRI.is_vector_relation(tp)
-            parm_json = PSRI.get_vector_map(data, col, rel; relation_type = tp)[json_to_bin]
-            parm_bin = PSRI.get_vector_map(data_bin, col, rel; relation_type = tp)
-            @assert parm_json == parm_bin
-        else
-            parm_json = PSRI.get_map(data, col, rel; relation_type = tp)[json_to_bin]
-            parm_bin = PSRI.get_map(data_bin, col, rel; relation_type = tp)
-            @assert parm_json == parm_bin
+    for (target, relations_vector) in relations
+        for relation in relations_vector
+            if verbose
+                println("Relation: ($col)-($target) of type $(relation.type)")
+            end
+            if PSRI.is_vector_relation(relation.type)
+                parm_json = PSRI.get_vector_map(data, col, target; relation_type = relation.type)[json_to_bin]
+                parm_bin = PSRI.get_vector_map(data_bin, col, target; relation_type = relation.type)
+                @assert parm_json == parm_bin
+            else
+                parm_json = PSRI.get_map(data, col, target; relation_type = relation.type)[json_to_bin]
+                parm_bin = PSRI.get_map(data_bin, col, target; relation_type = relation.type)
+                @assert parm_json == parm_bin
+            end
         end
     end
 end

--- a/test/modification_api.jl
+++ b/test/modification_api.jl
@@ -299,9 +299,15 @@ function test_api8() #tests delete_relation!
     @test PSRI.has_relations(data, "PSRBus", index2)
     @test PSRI.has_relations(data, "PSRSerie", index3)
 
-    @test PSRI.get_map(data, "PSRSerie", "PSRBus"; relation_type = PSRI.PMD.RELATION_FROM) ==
+    @test PSRI.get_map(
+        data,
+        "PSRSerie",
+        "PSRBus";
+        relation_type = PSRI.PMD.RELATION_FROM,
+    ) ==
           [2]
-    @test PSRI.get_map(data, "PSRSerie", "PSRBus"; relation_type = PSRI.PMD.RELATION_TO) == [1]
+    @test PSRI.get_map(data, "PSRSerie", "PSRBus"; relation_type = PSRI.PMD.RELATION_TO) ==
+          [1]
 
     PSRI.delete_relation!(data, "PSRSerie", "PSRBus", index3, index1)
     PSRI.delete_relation!(data, "PSRSerie", "PSRBus", index3, index2)
@@ -320,7 +326,12 @@ function test_api8() #tests delete_relation!
         "PSRBus";
         relation_type = PSRI.PMD.RELATION_FROM,
     ) == [0]
-    @test PSRI.get_map(data_copy, "PSRSerie", "PSRBus"; relation_type = PSRI.PMD.RELATION_TO) ==
+    @test PSRI.get_map(
+        data_copy,
+        "PSRSerie",
+        "PSRBus";
+        relation_type = PSRI.PMD.RELATION_TO,
+    ) ==
           [0]
 end
 

--- a/test/modification_api.jl
+++ b/test/modification_api.jl
@@ -158,7 +158,7 @@ function test_api4() # Tests set_related!() and set_vector_related!() methods
         "PSRSystem",
         index1,
         index3;
-        relation_type = PSRI.RELATION_1_TO_1,
+        relation_type = PSRI.PMD.RELATION_1_TO_1,
     )
     map = PSRI.get_map(data, "PSRThermalPlant", "PSRSystem")
     @test map == [1, 0]
@@ -221,7 +221,7 @@ function test_api6() #tests set_related_by_code!
         "PSRBus",
         index3,
         5;
-        relation_type = PSRI.RELATION_TO,
+        relation_type = PSRI.PMD.RELATION_TO,
     )
     PSRI.set_related_by_code!(
         data,
@@ -229,7 +229,7 @@ function test_api6() #tests set_related_by_code!
         "PSRBus",
         index3,
         6;
-        relation_type = PSRI.RELATION_FROM,
+        relation_type = PSRI.PMD.RELATION_FROM,
     )
 
     element = data.raw["PSRLinkDC"][index3]
@@ -282,7 +282,7 @@ function test_api8() #tests delete_relation!
         "PSRBus",
         index3,
         index1;
-        relation_type = PSRI.RELATION_TO,
+        relation_type = PSRI.PMD.RELATION_TO,
     )
     PSRI.set_related!(
         data,
@@ -290,7 +290,7 @@ function test_api8() #tests delete_relation!
         "PSRBus",
         index3,
         index2;
-        relation_type = PSRI.RELATION_FROM,
+        relation_type = PSRI.PMD.RELATION_FROM,
     )
 
     PSRI.write_data(data)
@@ -299,9 +299,9 @@ function test_api8() #tests delete_relation!
     @test PSRI.has_relations(data, "PSRBus", index2)
     @test PSRI.has_relations(data, "PSRSerie", index3)
 
-    @test PSRI.get_map(data, "PSRSerie", "PSRBus"; relation_type = PSRI.RELATION_FROM) ==
+    @test PSRI.get_map(data, "PSRSerie", "PSRBus"; relation_type = PSRI.PMD.RELATION_FROM) ==
           [2]
-    @test PSRI.get_map(data, "PSRSerie", "PSRBus"; relation_type = PSRI.RELATION_TO) == [1]
+    @test PSRI.get_map(data, "PSRSerie", "PSRBus"; relation_type = PSRI.PMD.RELATION_TO) == [1]
 
     PSRI.delete_relation!(data, "PSRSerie", "PSRBus", index3, index1)
     PSRI.delete_relation!(data, "PSRSerie", "PSRBus", index3, index2)
@@ -318,9 +318,9 @@ function test_api8() #tests delete_relation!
         data_copy,
         "PSRSerie",
         "PSRBus";
-        relation_type = PSRI.RELATION_FROM,
+        relation_type = PSRI.PMD.RELATION_FROM,
     ) == [0]
-    @test PSRI.get_map(data_copy, "PSRSerie", "PSRBus"; relation_type = PSRI.RELATION_TO) ==
+    @test PSRI.get_map(data_copy, "PSRSerie", "PSRBus"; relation_type = PSRI.PMD.RELATION_TO) ==
           [0]
 end
 

--- a/test/read_json2.jl
+++ b/test/read_json2.jl
@@ -40,7 +40,8 @@ capacity = PSRI.mapped_vector(data, "PSRThermalPlant", "PotInst", Float64)
     Int32[20, 33, 39, 51, 71, 86, 93, 109, 117]
 
 @test busFcur =
-    PSRI.get_map(data, "PSRSerie", "PSRBus"; relation_type = PSRI.PMD.RELATION_FROM) == Int32[
+    PSRI.get_map(data, "PSRSerie", "PSRBus"; relation_type = PSRI.PMD.RELATION_FROM) ==
+    Int32[
         1,
         1,
         1,

--- a/test/read_json2.jl
+++ b/test/read_json2.jl
@@ -40,7 +40,7 @@ capacity = PSRI.mapped_vector(data, "PSRThermalPlant", "PotInst", Float64)
     Int32[20, 33, 39, 51, 71, 86, 93, 109, 117]
 
 @test busFcur =
-    PSRI.get_map(data, "PSRSerie", "PSRBus"; relation_type = PSRI.RELATION_FROM) == Int32[
+    PSRI.get_map(data, "PSRSerie", "PSRBus"; relation_type = PSRI.PMD.RELATION_FROM) == Int32[
         1,
         1,
         1,
@@ -177,7 +177,7 @@ capacity = PSRI.mapped_vector(data, "PSRThermalPlant", "PotInst", Float64)
         117,
     ]
 @test busTcir =
-    PSRI.get_map(data, "PSRSerie", "PSRBus"; relation_type = PSRI.RELATION_TO) == Int32[
+    PSRI.get_map(data, "PSRSerie", "PSRBus"; relation_type = PSRI.PMD.RELATION_TO) == Int32[
         2,
         3,
         7,
@@ -335,7 +335,7 @@ capacity = PSRI.mapped_vector(data, "PSRThermalPlant", "PotInst", Float64)
     data,
     "PSRGenerator",
     "PSRBus";
-    original_relation_type = PSRI.RELATION_1_TO_1,
+    original_relation_type = PSRI.PMD.RELATION_1_TO_1,
 ) == Vector{Int32}[
     [],
     [],

--- a/test/read_json_relations_3.jl
+++ b/test/read_json_relations_3.jl
@@ -13,44 +13,44 @@ data = PSRI.initialize_study(
     data,
     "PSRHydroPlant",
     "PSRHydroPlant";
-    relation_type = PSRI.RELATION_TURBINE_TO,
+    relation_type = PSRI.PMD.RELATION_TURBINE_TO,
 ) == Int32[2, 0]
 @test PSRI.get_map(
     data,
     "PSRHydroPlant",
     "PSRHydroPlant";
-    relation_type = PSRI.RELATION_SPILL_TO,
+    relation_type = PSRI.PMD.RELATION_SPILL_TO,
 ) == Int32[2, 0]
 @test PSRI.get_map(
     data,
     "PSRHydroPlant",
     "PSRHydroPlant";
-    relation_type = PSRI.RELATION_INFILTRATE_TO,
+    relation_type = PSRI.PMD.RELATION_INFILTRATE_TO,
 ) == Int32[2, 0]
 @test PSRI.get_map(
     data,
     "PSRHydroPlant",
     "PSRHydroPlant";
-    relation_type = PSRI.RELATION_STORED_ENERGY_DONWSTREAM,
+    relation_type = PSRI.PMD.RELATION_STORED_ENERGY_DONWSTREAM,
 ) == Int32[2, 0]
 
 @test PSRI.get_map(
     data,
     "PSRInterconnection",
     "PSRSystem";
-    relation_type = PSRI.RELATION_FROM,
+    relation_type = PSRI.PMD.RELATION_FROM,
 ) == Int32[1]
 @test PSRI.get_map(
     data,
     "PSRInterconnection",
     "PSRSystem";
-    relation_type = PSRI.RELATION_TO,
+    relation_type = PSRI.PMD.RELATION_TO,
 ) == Int32[2]
 @test_throws ErrorException PSRI.get_vector_map(
     data,
     "PSRThermalPlant",
     "PSRFuelConsumption";
-    relation_type = PSRI.RELATION_1_TO_N,
+    relation_type = PSRI.PMD.RELATION_1_TO_N,
 )
 
 @test PSRI.get_vector_map(data, "PSRInterconnectionSumData", "PSRInterconnection") ==
@@ -83,19 +83,19 @@ data = PSRI.initialize_study(
     data,
     "PSRReserveGenerationConstraintData",
     "PSRThermalPlant";
-    relation_type = PSRI.RELATION_BACKED,
+    relation_type = PSRI.PMD.RELATION_BACKED,
 ) == Vector{Int32}[[]]
 @test PSRI.get_vector_map(
     data,
     "PSRReserveGenerationConstraintData",
     "PSRHydroPlant";
-    relation_type = PSRI.RELATION_BACKED,
+    relation_type = PSRI.PMD.RELATION_BACKED,
 ) == Vector{Int32}[[]]
 @test PSRI.get_vector_map(
     data,
     "PSRReserveGenerationConstraintData",
     "PSRGndPlant";
-    relation_type = PSRI.RELATION_BACKED,
+    relation_type = PSRI.PMD.RELATION_BACKED,
 ) == Vector{Int32}[[]]
 
 @test PSRI.get_vector_map(data, "PSRReservoirSet", "PSRHydroPlant") == Vector{Int32}[[1, 2]]
@@ -107,7 +107,7 @@ data = PSRI.initialize_study(
     data,
     "PSRHydroPlant",
     "PSRHydroPlant";
-    original_relation_type = PSRI.RELATION_TURBINE_TO,
+    original_relation_type = PSRI.PMD.RELATION_TURBINE_TO,
 ) == Vector{Int32}[[], [1]]
 
 # for each hydro - return its maintenance data
@@ -117,7 +117,7 @@ data = PSRI.initialize_study(
     data,
     "PSRMaintenanceData",
     "PSRHydroPlant";
-    original_relation_type = PSRI.RELATION_1_TO_1,
+    original_relation_type = PSRI.PMD.RELATION_1_TO_1,
 ) == Vector{Int32}[[1], []]
 
 # for each thermal - return all Gen Ctr it belongs

--- a/test/relations.jl
+++ b/test/relations.jl
@@ -14,7 +14,7 @@ function test_relations1() # tests _get_target_index_from_relation
             "PSRBus",
             1,
             1;
-            relation_type = PSRI.RELATION_FROM,
+            relation_type = PSRI.PMD.RELATION_FROM,
         )
         PSRI.set_related!(
             data,
@@ -22,7 +22,7 @@ function test_relations1() # tests _get_target_index_from_relation
             "PSRBus",
             1,
             2;
-            relation_type = PSRI.RELATION_TO,
+            relation_type = PSRI.PMD.RELATION_TO,
         )
 
         target_index = PSRI._get_target_index_from_relation(data, "PSRSerie", 1, "no1")
@@ -46,7 +46,7 @@ function test_relations2() # tests _get_sources_indices_from_relations
             "PSRBus",
             1,
             1;
-            relation_type = PSRI.RELATION_FROM,
+            relation_type = PSRI.PMD.RELATION_FROM,
         )
         PSRI.set_related!(
             data,
@@ -54,7 +54,7 @@ function test_relations2() # tests _get_sources_indices_from_relations
             "PSRBus",
             1,
             2;
-            relation_type = PSRI.RELATION_TO,
+            relation_type = PSRI.PMD.RELATION_TO,
         )
 
         source_indices = PSRI._get_sources_indices_from_relations(
@@ -84,7 +84,7 @@ function test_relations3() # tests has_relations
             "PSRBus",
             index3,
             index1;
-            relation_type = PSRI.RELATION_FROM,
+            relation_type = PSRI.PMD.RELATION_FROM,
         )
         PSRI.set_related!(
             data,
@@ -92,7 +92,7 @@ function test_relations3() # tests has_relations
             "PSRBus",
             index3,
             index2;
-            relation_type = PSRI.RELATION_TO,
+            relation_type = PSRI.PMD.RELATION_TO,
         )
 
         @test PSRI.has_relations(data, "PSRSerie", 1)


### PR DESCRIPTION
Currently, the relations are hard-coded. With this PR, we move the relations definitions to a JSON file that is loaded and stored in a dictionary in `Data`, in the attribute `Data.relation_mapper`. 

The user can define its own `relation_mapper` in a new JSON file. In a future PR, it will be possible to load the `relation_mapper` using a PMD file.