### PR TITLE
change next_registry order in docs

### DIFF
--- a/docs/src/examples/graf_files.md
+++ b/docs/src/examples/graf_files.md
@@ -231,8 +231,8 @@ ior = PSRI.open(
 data_from_file = zeros(n_agents, n_blocks, n_scenarios, n_stages)
 
 for stage = 1:n_stages, scenario = 1:n_scenarios, block = 1:n_blocks
-    PSRI.next_registry(ior)
     data_from_file[:, block, scenario, stage] = ior.data
+    PSRI.next_registry(ior)
 end
 
 PSRI.close(ior)


### PR DESCRIPTION
when reading a bin file using `iow = PSRI.open`, `ior.data` is already in its first element. Thus, inside the for loop, `PSRI.next_registry(ior)` might come after setting `data_from_file` so the array is in the same order as written