### PR TITLE
Add manual for files to the docs

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,4 +3,5 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterDiagrams = "a106ebf2-4182-4cba-90d4-44cd3cc36e85"
 
 [compat]
-Documenter = "0.27"
+Documenter = "~0.27"
+DocumenterDiagrams = "~0.27"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+DocumenterDiagrams = "a106ebf2-4182-4cba-90d4-44cd3cc36e85"
 
 [compat]
 Documenter = "0.27"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,6 +14,13 @@ makedocs(;
     pages = [
         "Home" => "index.md",
         "manual.md",
+        "Files and Structs manual" => String[
+            "file_types/file_diagram.md",
+            "file_types/pmd.md",
+            "file_types/model_template.md",
+            "file_types/relation_mapper.md",
+            "file_types/psrclasses.md",
+        ],
         "Examples" => String[
             "examples/reading_parameters.md",
             "examples/reading_relations.md",
@@ -21,12 +28,6 @@ makedocs(;
             "examples/reading_demands.md",
             "examples/modification.md",
             "examples/custom_study.md",
-        ],
-        "Files and Structs manual" => String[
-            "file_types/file_diagram.md",
-            "file_types/pmd.md",
-            "file_types/model_template.md",
-            "file_types/relation_mapper.md",
         ]
     ],
 )

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -28,7 +28,7 @@ makedocs(;
             "examples/reading_demands.md",
             "examples/modification.md",
             "examples/custom_study.md",
-        ]
+        ],
     ],
 )
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -22,10 +22,11 @@ makedocs(;
             "examples/modification.md",
             "examples/custom_study.md",
         ],
-        "File type manual" => String[
+        "Files and Structs manual" => String[
             "file_types/file_diagram.md",
             "file_types/pmd.md",
             "file_types/model_template.md",
+            "file_types/relation_mapper.md",
         ]
     ],
 )

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,4 +1,6 @@
 using Documenter
+using DocumenterDiagrams
+
 using PSRClassesInterface
 const PSRI = PSRClassesInterface
 
@@ -21,7 +23,9 @@ makedocs(;
             "examples/custom_study.md",
         ],
         "File type manual" => String[
-            "file_types/pmd.md"
+            "file_types/file_diagram.md",
+            "file_types/pmd.md",
+            "file_types/model_template.md",
         ]
     ],
 )

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -20,6 +20,9 @@ makedocs(;
             "examples/modification.md",
             "examples/custom_study.md",
         ],
+        "File type manual" => String[
+            "file_types/pmd.md"
+        ]
     ],
 )
 

--- a/docs/src/examples/modification.md
+++ b/docs/src/examples/modification.md
@@ -4,7 +4,7 @@ In this example we will be showing how to modify your study in runtime, adding/d
 
 ## Creating a Study
 
-You can modify a pre-existing study or a new one with the following functions:
+You can modify an existing study or a new one with the following functions:
 - [`PSRI.create_study`](@ref) &rarr; to create a new study;
 - [`PSRI.load_study`](@ref) &rarr; to load an old study.
 

--- a/docs/src/examples/modification.md
+++ b/docs/src/examples/modification.md
@@ -6,7 +6,7 @@ In this example we will be showing how to modify your study in runtime, adding/d
 
 You can modify a pre-existing study or a new one with the following functions:
 - [`PSRI.create_study`](@ref) &rarr; to create a new study;
-- [`PSRI.initialize_study`](@ref) &rarr; to load an old study.
+- [`PSRI.load_study`](@ref) &rarr; to load an old study.
 
 In this example, we will be working with a new empty study.
 

--- a/docs/src/examples/reading_demands.md
+++ b/docs/src/examples/reading_demands.md
@@ -8,7 +8,7 @@ const PSRI = PSRClassesInterface
 
 PATH_CASE_EXAMPLE_DEM = joinpath(pathof(PSRI) |> dirname |> dirname, "test", "data", "case1")
 
-data = PSRI.initialize_study(
+data = PSRI.load_study(
     PSRI.OpenInterface(),
     data_path = PATH_CASE_EXAMPLE_DEM
 )
@@ -108,7 +108,7 @@ const PSRI = PSRClassesInterface
 
 PATH_CASE_EXAMPLE_THER_PRICES = joinpath(pathof(PSRI) |> dirname |> dirname, "test", "data", "case1")
 
-data = PSRI.initialize_study(
+data = PSRI.load_study(
     PSRI.OpenInterface(),
     data_path = PATH_CASE_EXAMPLE_THER_PRICES
 )

--- a/docs/src/examples/reading_parameters.md
+++ b/docs/src/examples/reading_parameters.md
@@ -11,7 +11,7 @@ const PSRI = PSRClassesInterface
 
 PATH_CASE_EXAMPLE_CONFIGS = joinpath(pathof(PSRI) |> dirname |> dirname, "test", "data", "case0")
 
-data = PSRI.initialize_study(
+data = PSRI.load_study(
     PSRI.OpenInterface(),
     data_path = PATH_CASE_EXAMPLE_CONFIGS
 )
@@ -45,7 +45,7 @@ const PSRI = PSRClassesInterface
 
 PATH_CASE_EXAMPLE_THERMALS = joinpath(pathof(PSRI) |> dirname |> dirname, "test", "data", "case0")
 
-data = PSRI.initialize_study(
+data = PSRI.load_study(
     PSRI.OpenInterface(),
     data_path = PATH_CASE_EXAMPLE_THERMALS
 )
@@ -92,7 +92,7 @@ const PSRI = PSRClassesInterface
 
 PATH_CASE_EXAMPLE_BATTERIES = joinpath(pathof(PSRI) |> dirname |> dirname, "test", "data", "case1")
 
-data = PSRI.initialize_study(
+data = PSRI.load_study(
     PSRI.OpenInterface(),
     data_path = PATH_CASE_EXAMPLE_BATTERIES
 )

--- a/docs/src/examples/reading_relations.md
+++ b/docs/src/examples/reading_relations.md
@@ -36,7 +36,7 @@ const PSRI = PSRClassesInterface
 
 PATH_CASE_EXAMPLE_GAUGING = joinpath(pathof(PSRI) |> dirname |> dirname, "test", "data", "case2")
 
-data = PSRI.initialize_study(
+data = PSRI.load_study(
     PSRI.OpenInterface(),
     data_path = PATH_CASE_EXAMPLE_GAUGING
 )
@@ -58,7 +58,7 @@ const PSRI = PSRClassesInterface
 
 PATH_CASE_EXAMPLE_BUS = joinpath(pathof(PSRI) |> dirname |> dirname, "test", "data", "case1")
 
-data = PSRI.initialize_study(
+data = PSRI.load_study(
     PSRI.OpenInterface(),
     data_path = PATH_CASE_EXAMPLE_BUS
 )
@@ -94,7 +94,7 @@ const PSRI = PSRClassesInterface
 
 PATH_CASE_EXAMPLE_CIR_BUS = joinpath(pathof(PSRI) |> dirname |> dirname, "test", "data", "case1")
 
-data = PSRI.initialize_study(
+data = PSRI.load_study(
     PSRI.OpenInterface(),
     data_path = PATH_CASE_EXAMPLE_CIR_BUS
 )

--- a/docs/src/file_types/file_diagram.md
+++ b/docs/src/file_types/file_diagram.md
@@ -1,0 +1,17 @@
+# PSRI File flowchart
+
+```@diagram mermaid
+graph LR
+  PMD["PMD"]
+  MT["Model Template"]
+  DS["Data Struct"]
+  RM["Relation Mapper"]
+  D["Defaults"]
+  P["psrclasses.json"]
+  
+  PMD --> MT;
+  MT --> DS;
+  DS --> P;
+  RM --> P;
+  D --> P;
+```

--- a/docs/src/file_types/file_diagram.md
+++ b/docs/src/file_types/file_diagram.md
@@ -1,17 +1,73 @@
-# PSRI File flowchart
+# PSRI Files and Structs 101
+
+When creating or loading a study, PSRI uses different files.
+This flowchart shows the order in which the files are used.
+
+1. The classes and their attributes are defined in a `PMD` file.
+2. Then, a `Model Template` file is used to map the classes to collections in the study.
+3. Using the `Model Template` and the `PMD` file, the `Data Struct` file is created.
+4. PSRI loads the `Data Struct`, `Relation Mapper` and `Defaults` files into structs and create a study, whose data will be stored in a file named `psrclasses.json`.
 
 ```@diagram mermaid
+%%{init: {"flowchart": {"htmlLabels": false}} }%%
+
 graph LR
-  PMD["PMD"]
-  MT["Model Template"]
+  PMD[("PMD")]
+  MTF[("modeltemplates.json")]
   DS["Data Struct"]
+  RMF[("relations.json")]
   RM["Relation Mapper"]
+  DF[("defaults.json")]
   D["Defaults"]
-  P["psrclasses.json"]
-  
-  PMD --> MT;
-  MT --> DS;
+  P(("PSRI Study"))
+  S[("psrclasses.json")]
+
+
+  PMD --> DS;
+  MTF --> DS;
   DS --> P;
+  RMF --> RM;
   RM --> P;
+  DF --> D;
   D --> P;
+  P --> S;
 ```
+
+## How the structs are used
+
+### Creating an element
+
+When creating an element from a collection, PSRI uses the `Data Struct`, `Relation Mapper` and `Defaults` files to check if:
+- The collection is defined in the `Data Struct` file.
+- The element has all the attributes defined in the `Data Struct` file.
+- In the case where the element does not have all the attributes, the `Defaults` file has the remaining ones.
+
+
+```@diagram mermaid
+%%{init: {"flowchart": {"htmlLabels": false}} }%%
+
+graph TD
+  CEL["PSRI.create_element!(data,CollectionName)"]
+
+  Q1{"`Is the collection defined in the Data Struct?`"}
+  Q2{"`Does it have any missing attributes?`"}
+  Q3{"`Does the Defaults have the remaining attributes?`"}
+
+
+  E["`Error`"]
+  D["`Add to Study`"]
+
+  style E fill:#FF0000
+  style D fill:#00FF00
+
+  CEL --> Q1;
+  Q1 --"YES"--> Q2;
+  Q1 --"NO"--> E;
+  Q2 --"YES"--> Q3;
+  Q2 --"NO"--> D;
+  Q3 --"YES"--> D;
+  Q3 --"NO"--> E;
+```
+
+
+### Creating a relation

--- a/docs/src/file_types/file_diagram.md
+++ b/docs/src/file_types/file_diagram.md
@@ -71,3 +71,31 @@ graph TD
 
 
 ### Creating a relation
+
+When creating a relation between two collections, PSRI uses the `Relation Mapper` to check if:
+- The relation is defined in the `Relation Mapper`
+- The elements exist in the study
+
+
+```@diagram mermaid
+%%{init: {"flowchart": {"htmlLabels": false}} }%%
+
+graph TD
+  CEL["`PSRI.set_related!(data, Collection1, Collection2, ...)`"]
+
+  Q1{"`Is there a defined relation between the collections, with the exact parameters?`"}
+  Q2{"`Do the elements exist in the study?`"}
+
+
+  E["`Error`"]
+  D["`Add to Study`"]
+
+  style E fill:#FF0000
+  style D fill:#00FF00
+
+  CEL --> Q1;
+  Q1 --"YES"--> Q2;
+  Q1 --"NO"--> E;
+  Q2 --"YES"--> D;
+  Q2 --"NO"--> E;
+```

--- a/docs/src/file_types/model_template.md
+++ b/docs/src/file_types/model_template.md
@@ -1,0 +1,28 @@
+# Model Template
+
+The models defined in a [PMD](./pmd.md) file are mapped to collections in a PSRI study with a Model Template file.
+
+A Model Template is a JSON file with the following syntax.
+
+
+```json
+[
+    {
+        "classname": "CustomCollection",
+        "models": [
+            "Custom_Model_v1"
+        ]
+    },
+    {
+        "classname": "SecondCollection",
+        "models": [
+            "Another_Custom_Model_v1"
+        ]
+    }
+]
+```
+
+Inside `classname` you define the name of the collection that represents a model stated in `models`.
+This model is defined in a PMD file.
+
+To learn more about how to use custom PMD files with Model Templates, see the [Customizing a Study](../examples/custom_study.md) example.

--- a/docs/src/file_types/pmd.md
+++ b/docs/src/file_types/pmd.md
@@ -119,4 +119,7 @@ This difference between names is explained in the [Model Template manual](./mode
 
 Also, we define a `REFERENCE` only in the models which play the role of <i><b>source</b></i>. 
 
+There is another way to define relations in a study.
+For that, see the [Relation Mapper manual](relation_mapper.md).
+
 

--- a/docs/src/file_types/pmd.md
+++ b/docs/src/file_types/pmd.md
@@ -5,12 +5,12 @@
 > ⚠ **Warning:** The syntax for PMD files is case-sensitive 
 
 
-PMD files are used to define classes accross multiple PSR software.
+PMD files are used to define models accross multiple PSR software.
 It stores metadata about every attribute and relation.
 
-## Defining a class
+## Defining a model
 
-To define a class `Custom_Model_v1`, you need to use the following structure.
+To define a model `Custom_Model_v1`, you need to use the following structure.
 
 ```
 DEFINE_MODEL MODL:Custom_Model_v1

--- a/docs/src/file_types/pmd.md
+++ b/docs/src/file_types/pmd.md
@@ -109,15 +109,15 @@ END_MODEL
 ```
 
 In this example, our Custom_Model_v1 model has two relations:
-- a relation of `1 to 1` (for being a `PARM` parameter) with elements of collection <i>TargetCollection</i>
-- a relation of `1 to N` (for being a `VECTOR` parameter) with elements of collection <i>SecondTargetCollection</i>
+- a relation of `1 to 1` (for being a `PARM` parameter) with elements of collection TargetCollection
+- a relation of `1 to N` (for being a `VECTOR` parameter) with elements of collection SecondTargetCollection
 
-The `Plant` and `Items` parameters store the `reference_id` of the corresponding elements from collections <i>TargetCollection</i> and <i>SecondTargetCollection</i>, respectively.
+The `Plant` and `Items` parameters store the `reference_id` of the corresponding elements from collections TargetCollection and SecondTargetCollection, respectively.
 
-Note that the names <i>TargetCollection</i> and <i>SecondTargetCollection</i> are the name of the collections inside the study, not their name in the PMD file. 
+Note that the names TargetCollection and SecondTargetCollection are the name of the collections inside the study, not their name in the PMD file. 
 This difference between names is explained in the [Model Template manual](./model_template.md).
 
-Also, we define a `REFERENCE` only in the models which play the role of <i><b>source</b></i>. 
+Also, we define a `REFERENCE` only in the models which play the role of source. 
 
 There is another way to define relations in a study.
 For that, see the [Relation Mapper manual](relation_mapper.md).

--- a/docs/src/file_types/pmd.md
+++ b/docs/src/file_types/pmd.md
@@ -10,7 +10,7 @@ It stores metadata about every attribute and relation.
 
 ## Defining a model
 
-To define a model `Custom_Model_v1`, you need to use the following structure.
+To define a model `Custom_Model_v1`, you need to use the following structure:
 
 ```
 DEFINE_MODEL MODL:Custom_Model_v1
@@ -66,7 +66,7 @@ END_MODEL
 ### Parameters with dimension
 
 A `VECTOR` or `PARM` parameter can change according to a given Stage, Scenario and/or Block dimension (see the [Graf Files and Time Series](../examples/graf_files.md) example).
-We can specify whether a parameter is dimensioned using the following syntax.
+We can specify whether a parameter is dimensioned using the following syntax:
 ```
 DEFINE_MODEL MODL:Custom_Model_v1
 
@@ -84,5 +84,39 @@ DEFINE_MODEL MODL:Custom_Model_v1
 END_MODEL
 ```
 
+
+### `REFERENCE`
+
+Besides `REAL`, `INTEGER`, `STRING` and `DATE`, there is a fith attribute type labeled `REFERENCE`. 
+It can be stored either in a `VECTOR` or a `PARM`.
+
+A `REFERENCE` represents a relation between two models(or collections, when considering a PSRI study).
+
+It has the following structure:
+
+```
+DEFINE_MODEL MODL:Custom_Model_v1
+
+	...
+
+	PARM REFERENCE Plant TargetCollection  
+
+	VECTOR REFERENCE Items SecondTargetCollection
+
+	...
+
+END_MODEL
+```
+
+In this example, our Custom_Model_v1 model has two relations:
+- a relation of `1 to 1` (for being a `PARM` parameter) with elements of collection <i>TargetCollection</i>
+- a relation of `1 to N` (for being a `VECTOR` parameter) with elements of collection <i>SecondTargetCollection</i>
+
+The `Plant` and `Items` parameters store the `reference_id` of the corresponding elements from collections <i>TargetCollection</i> and <i>SecondTargetCollection</i>, respectively.
+
+Note that the names <i>TargetCollection</i> and <i>SecondTargetCollection</i> are the name of the collections inside the study, not their name in the PMD file. 
+This difference between names is explained in the [Model Template manual](./model_template.md).
+
+Also, we define a `REFERENCE` only in the models which play the role of <i><b>source</b></i>. 
 
 

--- a/docs/src/file_types/pmd.md
+++ b/docs/src/file_types/pmd.md
@@ -1,8 +1,10 @@
 # PMD
 
-> 💡 **Tip:** We have a syntax highlighter for .pmd files available on [Visual Studio's Marktetplace](https://marketplace.visualstudio.com/items?itemName=pedromxavier.psr-pmd)
+!!! tip
+    We have a syntax highlighter for .pmd files available on [Visual Studio's Marktetplace](https://marketplace.visualstudio.com/items?itemName=pedromxavier.psr-pmd)
 
-> ⚠ **Warning:** The syntax for PMD files is case-sensitive 
+!!! warning
+    The syntax for PMD files is case-sensitive 
 
 
 PMD files are used to define models accross multiple PSR software.

--- a/docs/src/file_types/pmd.md
+++ b/docs/src/file_types/pmd.md
@@ -1,0 +1,88 @@
+# PMD
+
+> 💡 **Tip:** We have a syntax highlighter for .pmd files available on [Visual Studio's Marktetplace](https://marketplace.visualstudio.com/items?itemName=pedromxavier.psr-pmd)
+
+> ⚠ **Warning:** The syntax for PMD files is case-sensitive 
+
+
+PMD files are used to define classes accross multiple PSR software.
+It stores metadata about every attribute and relation.
+
+## Defining a class
+
+To define a class `Custom_Model_v1`, you need to use the following structure.
+
+```
+DEFINE_MODEL MODL:Custom_Model_v1
+
+	...
+
+END_MODEL
+```
+
+## Defining a parameter
+
+A parameter can be either a `VECTOR` or a `PARM`.
+
+### `PARM`
+
+```
+DEFINE_MODEL MODL:Custom_Model_v1
+
+	...
+
+	PARM INTEGER Iterations
+	PARM REAL Price
+	PARM STRING Name
+	PARM DATE DateOfEvent
+
+	...
+
+END_MODEL
+```
+
+### `VECTOR`
+
+A `VECTOR` parameter can store the same types as a `PARM`.
+Additionally can have an indexing parameter attribute.
+
+
+Let's say that you have a vector `Cost` where each index corresponds to a cost in a specific date.
+We can use an auxiliary indexing vector `CostDates` to access the cost value correspondent to a given date (see the [Graf Files and Time Series](../examples/graf_files.md) example).
+
+```
+DEFINE_MODEL MODL:Custom_Model_v1
+
+	...
+
+	VECTOR DATE CostDates
+	VECTOR REAL Cost INDEX CostDates
+
+	...
+
+END_MODEL
+```
+
+### Parameters with dimension
+
+A `VECTOR` or `PARM` parameter can change according to a given Stage, Scenario and/or Block dimension (see the [Graf Files and Time Series](../examples/graf_files.md) example).
+We can specify whether a parameter is dimensioned using the following syntax.
+```
+DEFINE_MODEL MODL:Custom_Model_v1
+
+	...
+
+	PARM INTEGER Iterations DIM(block)
+
+	VECTOR REAL Duration DIM(block) 
+
+	VECTOR DATE CostDates
+	VECTOR REAL Cost DIM(block,segment) INDEX CostDates 
+
+	...
+
+END_MODEL
+```
+
+
+

--- a/docs/src/file_types/psrclasses.md
+++ b/docs/src/file_types/psrclasses.md
@@ -1,3 +1,40 @@
-# psrclasses.json and 
+# psrclasses.json and Defaults
 
 The `psrclasses.json` file stores the data from the PSRI study.
+
+It has the following structure:
+
+```json
+{
+    "CustomCollection": {
+        "AVId": "string",
+        "name": "name",
+        "code": 0,
+        "Values": [
+            0.0
+        ],
+        "Cost": 1.5
+    },
+    "SecondCollection": {
+        "AVId": "string2",
+        "name": "name2",
+        "Type": 3,
+        "Generation(1)": [
+            0.0,2.0
+        ],
+        "Generation(2)": [
+            5.0,3.0
+        ],
+        "code":1
+    }
+}
+
+```
+
+> ‼ **Important:** Note that in the `SecondCollection` there are two parameters `Generation(1)` and `Generation(2)`. They represent the values for the parameter `Generation` in two different dimensions.
+
+
+## Defaults
+
+The `defaults.json` file stores the default values for the parameters in the PSRI study. It has the same structure as the `psrclasses.json`.
+It is not a mandatory file, but it can be useful for the case when there are missing parameters for an element being created.

--- a/docs/src/file_types/psrclasses.md
+++ b/docs/src/file_types/psrclasses.md
@@ -1,0 +1,3 @@
+# psrclasses.json and 
+
+The `psrclasses.json` file stores the data from the PSRI study.

--- a/docs/src/file_types/psrclasses.md
+++ b/docs/src/file_types/psrclasses.md
@@ -31,7 +31,8 @@ It has the following structure:
 
 ```
 
-> ‼ **Important:** Note that in the `SecondCollection` there are two parameters `Generation(1)` and `Generation(2)`. They represent the values for the parameter `Generation` in two different dimensions.
+!!! note
+    In the `SecondCollection` there are two parameters `Generation(1)` and `Generation(2)`. They represent the values for the parameter `Generation` in two different dimensions.
 
 
 ## Defaults

--- a/docs/src/file_types/relation_mapper.md
+++ b/docs/src/file_types/relation_mapper.md
@@ -1,4 +1,50 @@
 # Relation Mapper
 
-You can also define relation between collection in a Study with a Relation Mapper file.
-It is a JSON 
+If you have already checked the [PMD manual](./pmd.md), you know that a PMD file can define relations between models.
+When these relations are parsed, they are stored in a Julia dictionary, the Relation Mapper.
+
+## Relation Mapper JSON file
+
+However, it is also possible to fill the Relation Mapper with a JSON file, that follows the same structure as PSRI's dictionary for relations.
+
+In the example below, we have a Relation Mapper file with the following information:
+- The model `CustomModel` has two relations defined, one with `SecondCollection` and another with `ThirdCollection`.
+    - The relation with `SecondCollection` is a `1_to_1` relation, and the parameter is called `system`. 
+    - The relation with `ThirdCollection` is a `1_to_N` relation, and the parameter is called `station`. 
+- The model `SecondCollection` has two relations with `FourthCollection`.
+    - The first relation with `FourthCollection` is a `FROM` relation, and the parameter is called `no1`.
+    - The second relation with `FourthCollection` is a `TO` relation, and the parameter is called `no2`.
+
+> 💭 **Reminder:** The relation parameter stores the `reference_id` from the element of the Target Collection. See [PMD manual](./pmd.md)
+
+
+```json
+{
+    "CustomCollection": {
+        "SecondCollection": {
+            "system": {
+                "is_vector": false,
+                "type": "1_TO_1"
+            }
+        },
+        "ThirdCollection": {
+            "station": {
+                "is_vector": true,
+                "type": "1_TO_N"
+            }
+        }
+    },
+    "SecondCollection": {
+        "FourthCollection": {
+            "no1": {
+                "is_vector": false,
+                "type": "FROM"
+            },
+            "no2": {
+                "is_vector": false,
+                "type": "TO"
+            }
+        }
+    }
+}
+```

--- a/docs/src/file_types/relation_mapper.md
+++ b/docs/src/file_types/relation_mapper.md
@@ -15,7 +15,8 @@ In the example below, we have a Relation Mapper file with the following informat
     - The first relation with `FourthCollection` is a `FROM` relation, and the parameter is called `no1`.
     - The second relation with `FourthCollection` is a `TO` relation, and the parameter is called `no2`.
 
-> 💭 **Reminder:** The relation parameter stores the `reference_id` from the element of the Target Collection. See [PMD manual](./pmd.md)
+!!! info "💭 Reminder"
+    The relation parameter stores the `reference_id` from the element of the Target Collection. See [PMD manual](./pmd.md)
 
 
 ```json

--- a/docs/src/file_types/relation_mapper.md
+++ b/docs/src/file_types/relation_mapper.md
@@ -1,0 +1,4 @@
+# Relation Mapper
+
+You can also define relation between collection in a Study with a Relation Mapper file.
+It is a JSON 

--- a/docs/src/manual.md
+++ b/docs/src/manual.md
@@ -16,7 +16,7 @@ const PSRI = PSRClassesInterface
 ```@docs
 PSRClassesInterface.AbstractData
 PSRClassesInterface.AbstractStudyInterface
-PSRClassesInterface.initialize_study
+PSRClassesInterface.load_study
 PSRClassesInterface.description
 PSRClassesInterface.max_elements
 ```

--- a/src/OpenStudy/study_openinterface.jl
+++ b/src/OpenStudy/study_openinterface.jl
@@ -223,7 +223,7 @@ function _merge_psr_transformer_and_psr_serie!(data::Data)
     return nothing
 end
 
-function initialize_study(
+function load_study(
     ::OpenInterface;
     data_path = "",
     pmd_files = String[],

--- a/src/study_interface.jl
+++ b/src/study_interface.jl
@@ -15,7 +15,7 @@ abstract type AbstractData end
 abstract type AbstractStudyInterface end
 
 """
-    initialize_study(::AbstractStudyInterface; kwargs...)
+    load_study(::AbstractStudyInterface; kwargs...)
 
 Initialize all data structures of the study.
 
@@ -27,13 +27,13 @@ Initialize all data structures of the study.
 Example:
 
 ```julia
-data = PSRI.initialize_study(
+data = PSRI.load_study(
     PSRI.OpenInterface();
     data_path = PATH_CASE_EXAMPLE_BATTERIES,
 )
 ```
 """
-function initialize_study end
+function load_study end
 
 """
     PSRI.get_vector(

--- a/test/duration.jl
+++ b/test/duration.jl
@@ -1,5 +1,5 @@
 function test_fixed_duration()
-    data = PSRI.initialize_study(
+    data = PSRI.load_study(
         PSRI.OpenInterface();
         data_path = joinpath(".", "data", "case1"),
     )
@@ -30,7 +30,7 @@ end
 test_fixed_duration()
 
 function test_hour_block_map_duration()
-    data = PSRI.initialize_study(
+    data = PSRI.load_study(
         PSRI.OpenInterface();
         data_path = joinpath(".", "data", "case2"),
     )
@@ -67,7 +67,7 @@ end
 test_hour_block_map_duration()
 
 function test_variable_duration()
-    data = PSRI.initialize_study(
+    data = PSRI.load_study(
         PSRI.OpenInterface();
         data_path = joinpath(".", "data", "case3"),
     )

--- a/test/graf_files.jl
+++ b/test/graf_files.jl
@@ -71,7 +71,7 @@ function test_graf()
     @test sort(PSRI.Tables.columnnames(graf_table)) == sort(column_names)
     @test haskey(graf_table, Symbol("X"))
 
-    data_copy = PSRI.initialize_study(PSRI.OpenInterface(); data_path = temp_path)
+    data_copy = PSRI.load_study(PSRI.OpenInterface(); data_path = temp_path)
 
     @test PSRI.has_graf_file(data_copy, "PSRDemand")
     @test PSRI.has_graf_file(data_copy, "PSRDemand", "Duracao")

--- a/test/loop_file.jl
+++ b/test/loop_file.jl
@@ -1,11 +1,11 @@
 PATH_CASE_0 = joinpath(@__DIR__, "data", "case0")
 
-data = PSRI.initialize_study(
+data = PSRI.load_study(
     PSRI.OpenInterface();
     data_path = PATH_CASE_0,
 )
 
-data_bin = PSRI.initialize_study(
+data_bin = PSRI.load_study(
     PSRI.OpenInterface();
     data_path = PATH_CASE_0,
 )

--- a/test/model_template.jl
+++ b/test/model_template.jl
@@ -47,7 +47,7 @@ function test_model_template1()
 
     PSRI.PMD.dump_model_template(mt_copy_path, data)
 
-    data_copy = PSRI.initialize_study(
+    data_copy = PSRI.load_study(
         PSRI.OpenInterface();
         data_path = temp_path,
         json_struct_path = data_struct_path,

--- a/test/modification_api.jl
+++ b/test/modification_api.jl
@@ -4,12 +4,12 @@ function test_api(data_path::String)
 
     mkpath(temp_path)
 
-    src_data = PSRI.initialize_study(PSRI.OpenInterface(); data_path = data_path)
+    src_data = PSRI.load_study(PSRI.OpenInterface(); data_path = data_path)
     raw_data = PSRI._raw(src_data)
 
     PSRI.write_data(src_data, json_path)
 
-    dest_data = PSRI.initialize_study(PSRI.OpenInterface(); data_path = temp_path)
+    dest_data = PSRI.load_study(PSRI.OpenInterface(); data_path = temp_path)
 
     @test PSRI._raw(dest_data) == raw_data
 
@@ -175,7 +175,7 @@ function test_api4() # Tests set_related!() and set_vector_related!() methods
 
     PSRI.write_data(data)
 
-    data_copy = PSRI.initialize_study(PSRI.OpenInterface(); data_path = temp_path)
+    data_copy = PSRI.load_study(PSRI.OpenInterface(); data_path = temp_path)
 
     map_copy = PSRI.get_map(data_copy, "PSRThermalPlant", "PSRSystem")
     @test map_copy == map
@@ -256,7 +256,7 @@ function test_api7() #tests delete_element!
     PSRI.delete_element!(data, "PSRBus", 3)
     PSRI.write_data(data)
 
-    data_copy = PSRI.initialize_study(PSRI.OpenInterface(); data_path = temp_path)
+    data_copy = PSRI.load_study(PSRI.OpenInterface(); data_path = temp_path)
 
     @test data_copy.raw["PSRBus"][3]["code"] == 8
     @test length(data_copy.raw["PSRBus"]) == 3
@@ -314,7 +314,7 @@ function test_api8() #tests delete_relation!
 
     PSRI.write_data(data)
 
-    data_copy = PSRI.initialize_study(PSRI.OpenInterface(); data_path = temp_path)
+    data_copy = PSRI.load_study(PSRI.OpenInterface(); data_path = temp_path)
 
     @test !PSRI.has_relations(data_copy, "PSRBus", index1)
     @test !PSRI.has_relations(data_copy, "PSRBus", index2)
@@ -369,7 +369,7 @@ function test_api9() #tests delete_vector_relation!
 
     PSRI.write_data(data)
 
-    data_copy = PSRI.initialize_study(PSRI.OpenInterface(); data_path = temp_path)
+    data_copy = PSRI.load_study(PSRI.OpenInterface(); data_path = temp_path)
 
     map_vec_copy = PSRI.get_vector_map(data_copy, "PSRThermalPlant", "PSRFuel")
     @test map_vec_copy == Vector{Int32}[[]]

--- a/test/read_json2.jl
+++ b/test/read_json2.jl
@@ -1,4 +1,4 @@
-data = PSRI.initialize_study(
+data = PSRI.load_study(
     PSRI.OpenInterface();
     data_path = joinpath(".", "data", "case1"),
 )

--- a/test/read_json_parameters.jl
+++ b/test/read_json_parameters.jl
@@ -1,6 +1,6 @@
 PATH_CASE_0 = joinpath(@__DIR__, "data", "case0")
 
-data = PSRI.initialize_study(
+data = PSRI.load_study(
     PSRI.OpenInterface();
     data_path = PATH_CASE_0,
 )

--- a/test/read_json_relations_3.jl
+++ b/test/read_json_relations_3.jl
@@ -1,4 +1,4 @@
-data = PSRI.initialize_study(
+data = PSRI.load_study(
     PSRI.OpenInterface();
     data_path = joinpath(".", "data", "case2"),
 )

--- a/test/study_api.jl
+++ b/test/study_api.jl
@@ -4,12 +4,12 @@ function test_api(data_path::String)
 
     mkpath(temp_path)
 
-    src_data = PSRI.initialize_study(PSRI.OpenInterface(); data_path = data_path)
+    src_data = PSRI.load_study(PSRI.OpenInterface(); data_path = data_path)
     raw_data = PSRI._raw(src_data)::Dict{String, <:Any}
 
     PSRI.write_data(src_data, json_path)
 
-    dest_data = PSRI.initialize_study(PSRI.OpenInterface(); data_path = temp_path)
+    dest_data = PSRI.load_study(PSRI.OpenInterface(); data_path = temp_path)
 
     @test PSRI._raw(dest_data) == raw_data
 


### PR DESCRIPTION
This PR adds a manual for the different files that PSRI uses.
It also renames `initialize_study` to `load_study`