### PR TITLE
Recover `initialize_study` with deprecation notice

### DIFF
--- a/src/OpenStudy/study_openinterface.jl
+++ b/src/OpenStudy/study_openinterface.jl
@@ -374,6 +374,15 @@ function load_study(
     return data
 end
 
+function initialize_study(args...; kws...)
+    @warn """
+        `initialize_study` is deprecated and will be removed in a future release.
+        Use `load_study` instead.
+    """
+
+    return load_study(args...; kws...)
+end
+
 function load_json_struct!(::Data, ::Nothing) end
 
 function load_json_struct!(data::Data, paths::Vector{String})


### PR DESCRIPTION
The removal of `initialize_study` broke functionality in [PSRClassesClassicInterface.jl](https://github.com/psrenergy/PSRClassesClassicInterface.jl).
This PR implements it as an alias for `load_study` with an additional deprecation notice.