### PR TITLE
[PMD] Make `MODL:` optional

### DIFF
--- a/src/PMD/parser/parser.jl
+++ b/src/PMD/parser/parser.jl
@@ -402,6 +402,10 @@ function _parse_line!(
         return nothing
     end
 
+    if _parse_merge!(parser, line, state)
+        return nothing
+    end
+
     if _parse_dimension!(parser, line, state)
         return nothing
     end
@@ -433,6 +437,10 @@ function _parse_line!(
     end
 
     if _parse_attribute!(parser, line, state)
+        return nothing
+    end
+
+    if _parse_merge!(parser, line, state)
         return nothing
     end
 
@@ -482,8 +490,8 @@ end
 function _parse_merge!(
     parser::Parser,
     line::AbstractString,
-    state::PMD_DEF_MODEL,
-)
+    state::S,
+) where {S<:Union{PMD_DEF_MODEL, PMD_DEF_CLASS, PMD_MERGE_CLASS}}
     m = match(r"MERGE_MODEL\s+(MODL:)?(\S+)", line)
 
     if m !== nothing

--- a/src/PMD/parser/parser.jl
+++ b/src/PMD/parser/parser.jl
@@ -491,7 +491,7 @@ function _parse_merge!(
     parser::Parser,
     line::AbstractString,
     state::S,
-) where {S<:Union{PMD_DEF_MODEL, PMD_DEF_CLASS, PMD_MERGE_CLASS}}
+) where {S <: Union{PMD_DEF_MODEL, PMD_DEF_CLASS, PMD_MERGE_CLASS}}
     m = match(r"MERGE_MODEL\s+(MODL:)?(\S+)", line)
 
     if m !== nothing

--- a/src/PMD/parser/parser.jl
+++ b/src/PMD/parser/parser.jl
@@ -485,10 +485,10 @@ function _parse_merge!(
     line::AbstractString,
     state::PMD_DEF_MODEL,
 )
-    m = match(r"MERGE_MODEL\s+MODL:(\S+)", line)
+    m = match(r"MERGE_MODEL\s+(MODL:)?(\S+)", line)
 
     if m !== nothing
-        model_name = String(m[1])
+        model_name = String(m[2])
 
         _cache_merge!(parser, state.collection, model_name)
 

--- a/src/PMD/parser/parser.jl
+++ b/src/PMD/parser/parser.jl
@@ -81,7 +81,7 @@ function _error(
     return error("Error in '$(parser.path):$(parser.lineno)': $msg")
 end
 
-function _syntax_warning(
+function _warning(
     parser::Parser,
     msg::AbstractString,
 )
@@ -91,15 +91,18 @@ function _syntax_warning(
 end
 
 function _cache_merge!(parser::Parser, collection::String, model_name::String)
-    if !haskey(parser.model_template.inv, model_name)
-        _error(parser, "'$model_name' not found in model template")
-    end
-
     if !haskey(parser.merge, collection)
         parser.merge[collection] = []
     end
 
-    push!(parser.merge[collection], parser.model_template.inv[model_name])
+    if !haskey(parser.model_template.inv, model_name)
+        _warning(parser, "'$model_name' not found in model template")
+    end
+
+    push!(
+        parser.merge[collection],
+        get(parser.model_template.inv, model_name, model_name),
+    )
 
     return nothing
 end
@@ -115,7 +118,13 @@ function _apply_merge!(parser::Parser, target::String, merge_path::Set{String})
 
     for source in parser.merge[target]
         if source in merge_path
-            error("Circular merge between '$target' and '$source'")
+            _error(parser, "Circular merge between '$target' and '$source'")
+        end
+
+        if !haskey(parser.data_struct, source)
+            _warning(parser, "Unknown collection '$source' for merging into '$target'")
+
+            continue
         end
 
         _merge_path = deepcopy(merge_path)
@@ -154,17 +163,17 @@ function _apply_tag!(
     tag::AbstractString,
 )
     if tag == "@id"
-        _syntax_warning(
+        _warning(
             parser,
             "Unhandled '$tag' tag for '$(attribute)' within '$(collection)' definition",
         )
     elseif tag == "@hourly_dense"
-        _syntax_warning(
+        _warning(
             parser,
             "Unhandled '$tag' tag for '$(attribute)' within '$(collection)' definition",
         )
     elseif tag == "@chronological"
-        _syntax_warning(
+        _warning(
             parser,
             "Unhandled '$tag' tag for '$(attribute)' within '$(collection)' definition",
         )
@@ -253,17 +262,7 @@ function _parse_line!(parser::Parser, line::AbstractString, ::PMD_IDLE)
     if m !== nothing
         model_name = String(m[2])
 
-        if _hasinv(parser.model_template, model_name)
-            collection = parser.model_template.inv[model_name]
-        else
-            _syntax_warning(parser, "Unknown model '$(model_name)'")
-
-            # By setting the collection to 'nothing', we are telling
-            # the parser to ignore the block and its contents
-            _push_state!(parser, PMD_DEF_MODEL(nothing))
-
-            return nothing
-        end
+        collection = get(parser.model_template.inv, model_name, model_name)
 
         parser.data_struct[collection] = Dict{String, Attribute}()
 
@@ -317,7 +316,7 @@ function _parse_line!(parser::Parser, line::AbstractString, ::PMD_IDLE)
 
             return nothing
         else
-            _syntax_warning(parser, "Unknown model '$(model_name)'")
+            _warning(parser, "Unknown model '$(model_name)'")
 
             # By setting the collection to 'nothing', we are telling
             # the parser to ignore the block and its contents
@@ -509,7 +508,7 @@ function _parse_submodel!(
         src_model = String(m[2])
         dst_model = String(m[4])
 
-        _syntax_warning(
+        _warning(
             parser,
             "Unhandled 'SUB_MODEL' statement from $(src_model) to $(dst_model) within $(state.collection)",
         )
@@ -528,7 +527,7 @@ function _parse_dimension!(
     m = match(r"DIMENSION\s+(\S+)", line)
 
     if m !== nothing
-        _syntax_warning(
+        _warning(
             parser,
             "Unhandled dimension '$(m[1])' within '$(state.collection)'",
         )
@@ -621,12 +620,12 @@ function _parse_inline_tag!(
 
     if m !== nothing
         if m[2] !== nothing
-            _syntax_warning(
+            _warning(
                 parser,
                 "Unhandled inline tag '$(m[1])' with args: '$(m[2])'",
             )
         else
-            _syntax_warning(
+            _warning(
                 parser,
                 "Unhandled inline tag '$(m[1])' with no args",
             )

--- a/test/pmd_parser.jl
+++ b/test/pmd_parser.jl
@@ -317,7 +317,7 @@ function test_pmd_source_2()
             "PSRLoad" => Dict(
                 "AVId" => PSRI.PMD.Attribute("AVId", false, String, 0, ""),
                 "name" => PSRI.PMD.Attribute("name", false, String, 0, ""),
-                "P"    => PSRI.PMD.Attribute("P", true, Float64, 1, "Data"),
+                "P" => PSRI.PMD.Attribute("P", true, Float64, 1, "Data"),
                 "PerF" => PSRI.PMD.Attribute("PerF", true, Float64, 1, "Data"),
                 "Data" => PSRI.PMD.Attribute("Data", true, Dates.Date, 0, ""),
                 "Pind" => PSRI.PMD.Attribute("Pind", true, Float64, 1, "Data"),

--- a/test/pmd_parser.jl
+++ b/test/pmd_parser.jl
@@ -1,6 +1,16 @@
 function test_pmd_parser()
+    test_pmd_source_0()
+    test_pmd_source_1()
+    test_pmd_source_2()
+    test_pmd_source_3()
+    test_pmd_source_3_relations()
+
+    return nothing
+end
+
+function test_pmd_source_0()
     model_template = PSRI.PMD.load_model_template(
-        joinpath(@__DIR__, "..", "src", "json_metadata", "modeltemplates.sddp.json"),
+        joinpath(PSRI.JSON_METADATA_PATH, "modeltemplates.sddp.json"),
     )
 
     @testset "source0.pmd" begin
@@ -184,22 +194,274 @@ function test_pmd_parser()
             ),
         )
     end
+
+    return nothing
 end
 
-function test_pmd_parser_2()
+function test_pmd_source_1()
+    model_template = PSRI.PMD.load_model_template(
+        joinpath(PSRI.JSON_METADATA_PATH, "modeltemplates.sddp.json"),
+    )
+
+    @testset "source1.pmd" begin
+        path = joinpath(@__DIR__, "data", "pmd", "source1.pmd")
+        data = PSRI.PMD.parse(path, model_template; verbose = true)
+
+        @test data == Dict{String, Dict{String, PSRI.PMD.Attribute}}(
+            "Contract_Forward" => Dict(
+                "AVId" =>
+                    PSRI.PMD.Attribute("AVId", false, String, 0, ""),
+                "name" =>
+                    PSRI.PMD.Attribute("name", false, String, 0, ""),
+                "SpreadUnit" => PSRI.PMD.Attribute(
+                    "SpreadUnit",
+                    false,
+                    Int32,
+                    0,
+                    "",
+                ),
+                "Spread" =>
+                    PSRI.PMD.Attribute("Spread", false, Float64, 0, ""),
+                "code" =>
+                    PSRI.PMD.Attribute("code", false, Int32, 0, ""),
+            ),
+            "PSRGeneratorUnit" => Dict(
+                "AVId" =>
+                    PSRI.PMD.Attribute("AVId", false, String, 0, ""),
+                "name" =>
+                    PSRI.PMD.Attribute("name", false, String, 0, ""),
+                "FixedOEM" => PSRI.PMD.Attribute(
+                    "FixedOEM",
+                    true,
+                    Float64,
+                    0,
+                    "DataOptfolio",
+                ),
+                "Code" =>
+                    PSRI.PMD.Attribute("Code", false, Int32, 0, ""),
+                "code" =>
+                    PSRI.PMD.Attribute("code", false, Int32, 0, ""),
+                "NumberUnits" => PSRI.PMD.Attribute(
+                    "NumberUnits",
+                    false,
+                    Int32,
+                    0,
+                    "",
+                ),
+            ),
+            "MODELX" => Dict(
+                "DataHP" => PSRI.PMD.Attribute(
+                    "DataHP",
+                    true,
+                    Dates.Date,
+                    0,
+                    "",
+                ),
+                "code" =>
+                    PSRI.PMD.Attribute("code", false, Int32, 0, ""),
+                "DataN" =>
+                    PSRI.PMD.Attribute("DataN", false, String, 0, ""),
+                "DataDP" => PSRI.PMD.Attribute(
+                    "DataDP",
+                    true,
+                    Dates.Date,
+                    0,
+                    "",
+                ),
+                "AVId" =>
+                    PSRI.PMD.Attribute("AVId", false, String, 0, ""),
+                "name" =>
+                    PSRI.PMD.Attribute("name", false, String, 0, ""),
+                "DataD" => PSRI.PMD.Attribute(
+                    "DataD",
+                    false,
+                    Dates.Date,
+                    0,
+                    "",
+                ),
+                "DataPTS" => PSRI.PMD.Attribute(
+                    "DataPTS",
+                    true,
+                    Float64,
+                    1,
+                    "DataP",
+                ),
+                "DataP" =>
+                    PSRI.PMD.Attribute("DataP", false, Float64, 0, ""),
+                "DataU" =>
+                    PSRI.PMD.Attribute("DataU", false, Int32, 0, ""),
+                "DataPHTS" => PSRI.PMD.Attribute(
+                    "DataPHTS",
+                    true,
+                    Float64,
+                    0,
+                    "DataHP",
+                ),
+            ),
+        )
+    end
+
+    return nothing
+end
+
+function test_pmd_source_2()
+    model_template = PSRI.PMD.load_model_template(
+        joinpath(PSRI.JSON_METADATA_PATH, "modeltemplates.sddp.json"),
+    )
+
+    @testset "source2.pmd" begin
+        path = joinpath(@__DIR__, "data", "pmd", "source2.pmd")
+        data = PSRI.PMD.parse(path, model_template; verbose = true)
+
+        @test data == Dict{String, Dict{String, PSRI.PMD.Attribute}}(
+            "PSRLoad" => Dict(
+                "AVId" => PSRI.PMD.Attribute("AVId", false, String, 0, ""),
+                "name" => PSRI.PMD.Attribute("name", false, String, 0, ""),
+                "P"    => PSRI.PMD.Attribute("P", true, Float64, 1, "Data"),
+                "PerF" => PSRI.PMD.Attribute("PerF", true, Float64, 1, "Data"),
+                "Data" => PSRI.PMD.Attribute("Data", true, Dates.Date, 0, ""),
+                "Pind" => PSRI.PMD.Attribute("Pind", true, Float64, 1, "Data"),
+                "code" => PSRI.PMD.Attribute("code", false, Int32, 0, ""),
+                "icca" => PSRI.PMD.Attribute("icca", true, Int32, 0, ""),
+            ),
+        )
+    end
+
+    return nothing
+end
+
+function test_pmd_source_3()
+    model_template = PSRI.PMD.load_model_template(
+        joinpath(PSRI.JSON_METADATA_PATH, "modeltemplates.sddp.json"),
+    )
+
+    @testset "source3.pmd" begin
+        path = joinpath(@__DIR__, "data", "pmd", "source3.pmd")
+        data = PSRI.PMD.parse(path, model_template; verbose = true)
+
+        @test data == Dict{String, Dict{String, PSRI.PMD.Attribute}}(
+            "PSRElement" => Dict(
+                "AVId" =>
+                    PSRI.PMD.Attribute("AVId", false, String, 0, ""),
+                "name" =>
+                    PSRI.PMD.Attribute("name", false, String, 0, ""),
+                "Code" =>
+                    PSRI.PMD.Attribute("Code", false, Int32, 0, ""),
+                "code" =>
+                    PSRI.PMD.Attribute("code", false, Int32, 0, ""),
+                "NumberUnits" => PSRI.PMD.Attribute(
+                    "NumberUnits",
+                    false,
+                    Int32,
+                    0,
+                    "",
+                ),
+            ),
+            "PSRBus" => Dict(
+                "AVId" =>
+                    PSRI.PMD.Attribute("AVId", false, String, 0, ""),
+                "name" =>
+                    PSRI.PMD.Attribute("name", false, String, 0, ""),
+                "Code" =>
+                    PSRI.PMD.Attribute("Code", false, Int32, 0, ""),
+                "code" =>
+                    PSRI.PMD.Attribute("code", false, Int32, 0, ""),
+                "NumberUnits" => PSRI.PMD.Attribute(
+                    "NumberUnits",
+                    false,
+                    Int32,
+                    0,
+                    "",
+                ),
+            ),
+            "PSRTest" => Dict(
+                "AVId" =>
+                    PSRI.PMD.Attribute("AVId", false, String, 0, ""),
+                "name" =>
+                    PSRI.PMD.Attribute("name", false, String, 0, ""),
+                "Code" =>
+                    PSRI.PMD.Attribute("Code", false, Int32, 0, ""),
+                "code" =>
+                    PSRI.PMD.Attribute("code", false, Int32, 0, ""),
+                "NumberUnits" => PSRI.PMD.Attribute(
+                    "NumberUnits",
+                    false,
+                    Int32,
+                    0,
+                    "",
+                ),
+            ),
+            "PSRGeneratorUnit" => Dict(
+                "AVId" =>
+                    PSRI.PMD.Attribute("AVId", false, String, 0, ""),
+                "name" =>
+                    PSRI.PMD.Attribute("name", false, String, 0, ""),
+                "Code" =>
+                    PSRI.PMD.Attribute("Code", false, Int32, 0, ""),
+                "Date" =>
+                    PSRI.PMD.Attribute("Date", true, Dates.Date, 0, ""),
+                "code" =>
+                    PSRI.PMD.Attribute("code", false, Int32, 0, ""),
+                "NumberUnits" => PSRI.PMD.Attribute(
+                    "NumberUnits",
+                    false,
+                    Int32,
+                    0,
+                    "",
+                ),
+            ),
+            "Custom_StudyConfig" => Dict(
+                "AVId" =>
+                    PSRI.PMD.Attribute("AVId", false, String, 0, ""),
+                "name" =>
+                    PSRI.PMD.Attribute("name", false, String, 0, ""),
+                "Ano_inicial" => PSRI.PMD.Attribute(
+                    "Ano_inicial",
+                    false,
+                    Int32,
+                    0,
+                    "",
+                ),
+                "Tipo_Etapa" => PSRI.PMD.Attribute(
+                    "Tipo_Etapa",
+                    false,
+                    Int32,
+                    0,
+                    "",
+                ),
+                "code" =>
+                    PSRI.PMD.Attribute("code", false, Int32, 0, ""),
+                "Etapa_inicial" => PSRI.PMD.Attribute(
+                    "Etapa_inicial",
+                    false,
+                    Int32,
+                    0,
+                    "",
+                ),
+            ),
+        )
+    end
+
+    return nothing
+end
+
+function test_pmd_source_3_relations()
     model_template = PSRI.PMD.load_model_template(
         joinpath(@__DIR__, "data", "model_template_test", "modeltemplates.source3.json"),
     )
+
     pmds_path = [joinpath(@__DIR__, "data", "pmd", "source3.pmd")]
 
     @testset "source3.pmd" begin
         relation_mapper = PSRI.PMD.RelationMapper()
+
         PSRI.PMD.load_model(
             "",
             pmds_path,
             model_template,
             relation_mapper,
         )
+
         @test relation_mapper == PSRI.PMD.RelationMapper(
             Dict(
                 "PSRGeneratorUnit" =>
@@ -239,4 +501,3 @@ function test_pmd_parser_2()
 end
 
 test_pmd_parser()
-test_pmd_parser_2()


### PR DESCRIPTION
Make `MODL:` optional instead of required in `MERGE_MODEL` statements.