### PR TITLE
Add read only mode

### DIFF
--- a/src/PSRDatabaseSQLite/database_sqlite.jl
+++ b/src/PSRDatabaseSQLite/database_sqlite.jl
@@ -60,8 +60,11 @@ end
 
 function DatabaseSQLite(
     database_path::String,
+    read_only::Bool = false,
 )
-    sqlite_db = SQLite.DB(database_path)
+    sqlite_db =
+        read_only ? SQLite.DB("file:" * database_path * "?mode=ro") :
+        SQLite.DB(database_path)
 
     collections_map = try
         _validate_database(sqlite_db)

--- a/src/PSRDatabaseSQLite/psri_study_interface.jl
+++ b/src/PSRDatabaseSQLite/psri_study_interface.jl
@@ -45,8 +45,9 @@ end
 
 PSRI.load_study(
     ::PSRDatabaseSQLiteInterface,
-    data_path::String,
-) = PSRDatabaseSQLite.load_db(data_path)
+    data_path::String;
+    read_only::Bool = false,
+) = PSRDatabaseSQLite.load_db(data_path, read_only)
 
 PSRI.load_study(
     ::PSRDatabaseSQLiteInterface,

--- a/src/PSRDatabaseSQLite/utils.jl
+++ b/src/PSRDatabaseSQLite/utils.jl
@@ -72,10 +72,11 @@ function create_empty_db_from_migrations(
     return db
 end
 
-function load_db(database_path::String)
+function load_db(database_path::String, read_only::Bool = false)
     db = try
         DatabaseSQLite(
             database_path,
+            read_only,
         )
     catch e
         rethrow(e)

--- a/test/PSRDatabaseSQLite/test_read_only/test_read_only.jl
+++ b/test/PSRDatabaseSQLite/test_read_only/test_read_only.jl
@@ -1,0 +1,67 @@
+module TestReadOnly
+
+using PSRClassesInterface.PSRDatabaseSQLite
+using SQLite
+using Dates
+using Test
+
+function test_read_only()
+    path_schema = joinpath(@__DIR__, "test_read_only.sql")
+    db_path = joinpath(@__DIR__, "test_read_only.sqlite")
+    db = PSRDatabaseSQLite.create_empty_db_from_schema(db_path, path_schema; force = true)
+    PSRDatabaseSQLite.create_element!(
+        db,
+        "Configuration";
+        label = "Toy Case",
+        date_initial = DateTime(2020, 1, 1),
+    )
+    PSRDatabaseSQLite.create_element!(
+        db,
+        "Resource";
+        label = "Resource 1",
+        some_value = [1, 2, 3.0],
+    )
+    PSRDatabaseSQLite.create_element!(
+        db,
+        "Resource";
+        label = "Resource 2",
+        some_value = [1, 2, 4.0],
+    )
+
+    PSRDatabaseSQLite.close!(db)
+
+    db = PSRDatabaseSQLite.load_db(db_path, true)
+
+    @test PSRDatabaseSQLite.read_scalar_parameters(db, "Configuration", "label") ==
+          ["Toy Case"]
+    @test PSRDatabaseSQLite.read_scalar_parameters(db, "Resource", "label") ==
+          ["Resource 1", "Resource 2"]
+    @test PSRDatabaseSQLite.read_scalar_parameter(db, "Resource", "label", "Resource 1") ==
+          "Resource 1"
+
+    @test_throws SQLite.SQLiteException PSRDatabaseSQLite.create_element!(
+        db,
+        "Resource";
+        label = "Resource 3",
+        some_value = [1, 2, 3.0],
+    )
+
+    PSRDatabaseSQLite.close!(db)
+    return rm(db_path)
+end
+
+function runtests()
+    Base.GC.gc()
+    Base.GC.gc()
+    for name in names(@__MODULE__; all = true)
+        if startswith("$name", "test_")
+            @testset "$(name)" begin
+                getfield(@__MODULE__, name)()
+            end
+        end
+    end
+end
+
+TestReadOnly.runtests()
+
+end

--- a/test/PSRDatabaseSQLite/test_read_only/test_read_only.sql
+++ b/test/PSRDatabaseSQLite/test_read_only/test_read_only.sql
@@ -1,0 +1,17 @@
+PRAGMA user_version = 1;
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE Configuration (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    label TEXT UNIQUE,
+    value1 REAL NOT NULL DEFAULT 100,
+    date_initial TEXT,
+    enum1 TEXT NOT NULL DEFAULT 'A' CHECK(enum1 IN ('A', 'B', 'C'))
+) STRICT;
+
+
+CREATE TABLE Resource (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    label TEXT UNIQUE,
+    type TEXT NOT NULL DEFAULT "D" CHECK(type IN ('D', 'E', 'F'))
+) STRICT;


### PR DESCRIPTION
This PR allows the user to load a database in "Read only" mode.

Currently, we have two dispatches for `PSRI.load_study`, one that applies a migration first (if needed), and another that just loads the database. 

When applying a migration, the database should not be in "Read only" mode, so for the second dispatch, I have added a boolean parameter (default = false) that sets the loading mode.

So when a user uses 

```julia
db = PSRI.load_study(PSRI.PSRDatabaseSQLiteInterface(), database_path; read_only = true)
```

they can only perform reading queries and cannot modify the database.
